### PR TITLE
Fixed error from totals.py while timer is active

### DIFF
--- a/ext/totals.py
+++ b/ext/totals.py
@@ -97,6 +97,11 @@ if 'temp.report.start' not in configuration:
     print('There is no data in the database')
     exit()
 
+if 'temp.report.end' not in configuration:
+    configuration.update( {
+        'temp.report.end': datetime.datetime.now().strftime( '%Y%m%dT%H%M%SZ' )
+    } )
+
 start = datetime.datetime.strptime(configuration['temp.report.start'], DATEFORMAT)
 end = datetime.datetime.strptime(configuration['temp.report.end'], DATEFORMAT)
 


### PR DESCRIPTION
I got the following error when I tried to run totals.py while a task was not finished:

    Traceback (most recent call last):
      File "/home/davis/.timewarrior/extensions/totals.py", line 101, in <module>
        end = datetime.datetime.strptime(configuration['temp.report.end'], DATEFORMAT)
    KeyError: 'temp.report.end'

This change fixed that for me.