### PR TITLE
#138 Escape '"' in tags for JSON output

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -160,7 +160,7 @@ std::string Interval::json () const
       if (tags[0])
         tags += ',';
 
-      tags += "\"" + tag + "\"";
+      tags += "\"" + escape (tag, '"') + "\"";
     }
 
     if (range.start.toEpoch () ||


### PR DESCRIPTION
This fixes #138 