### PR TITLE
#21 Add/Remove tags to/from current interval

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ Thanks to the following, who submitted detailed bug reports and excellent sugges
   chronitis
   rudis
   bognolo
+  lumbric

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 1.2.0 () -
-
+- #21     Add/Remove tag to/from current activity (TI-13)
+          (thanks to lumbric)
 - #98     Command Injection Security Vulnerability in on-modify.timewarrior (TI-94)
           (thanks to Aaron Fields)
 - #104    :lastquarter throws exception in first quarter (TI-100)

--- a/doc/man/timew.1.in
+++ b/doc/man/timew.1.in
@@ -375,7 +375,7 @@ modification.
 See also 'day', 'week', 'month', 'shorten', 'lengthen', 'tag', 'untag'.
 
 .TP
-.B timew tag @<id> [@<id> ...] <tag> [<tag> ...]
+.B timew tag [@<id> ...] <tag> ...
 The 'tag' command is used to add a tag to an interval. Using the 'summary'
 command, and specifying the ':ids' hint shows interval IDs. Using the right ID,
 you can identify an interval to tag. For example, show the IDs:
@@ -389,6 +389,13 @@ Then having selected '@2' as the interval you wish to tag:
 Note that you can tag multiple intervals, with multiple tags:
 
   $ timew tag @2 @10 @23 'Tag One' tag2 tag3
+
+If there is active time tracking, you can omit the ID when you want to add tags to the current open interval:
+
+  $ timew start foo
+  $ timew tag bar
+
+This results in the current interval having tags 'foo' and 'bar'.
 
 See also 'summary', 'shorten', 'lengthen', 'untag'.
 
@@ -410,7 +417,7 @@ recording. If a closed interval is not provided, the 'track' command behaves the
 same as the 'start' command.
 
 .TP
-.B timew untag @<id> [@<id> ...] <tag> [<tag> ...]
+.B timew untag [@<id> ...] <tag> ...
 The 'untag' command is used to remove a tag from an interval. Using the 'summary'
 command, and specifying the ':ids' hint shows interval IDs. Using the right ID,
 you can identify an interval to untag. For example, show the IDs:
@@ -424,6 +431,13 @@ Then having selected '@2' as the interval you wish to untag:
 Note that you can untag multiple intervals, with multiple tags:
 
   $ timew untag @2 @10 @23 'Old Tag' tag2 tag3
+
+If there is active time tracking, you can omit the ID when you want to remove tags from the current open interval:
+
+  $ timew start foo bar
+  $ timew untag bar
+
+This results in the current interval having tag 'foo' but not 'bar'.
 
 See also 'summary', 'shorten', 'lengthen', 'tag'.
 

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -539,3 +539,17 @@ std::set<int> CLI::getIds() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+std::vector<std::string> CLI::getTags () const
+{
+  std::vector <std::string> tags;
+
+  for (auto& arg : _args)
+  {
+    if (arg.hasTag ("TAG"))
+      tags.push_back (arg.attribute ("raw"));
+  }
+
+  return tags;
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/src/CLI.h
+++ b/src/CLI.h
@@ -66,6 +66,7 @@ public:
   std::string getBinary () const;
   std::string getCommand () const;
   std::set <int> getIds () const;
+  std::vector<std::string> getTags () const;
   std::string dump (const std::string& title = "CLI Parser") const;
 
 private:

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -76,7 +76,17 @@ int CmdTag (
 
   if (ids.empty ())
   {
-    throw std::string ("At least one ID must be specified. See 'timew help tag'.");
+    if (tracked.empty ())
+    {
+      throw std::string ("There is no active time tracking.");
+    }
+
+    if (!tracked.back ().range.is_open ())
+    {
+      throw std::string ("At least one ID must be specified. See 'timew help tag'.");
+    }
+
+    ids.insert (1);
   }
 
   // Apply tags to ids.

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -41,14 +41,11 @@ int CmdTag (
   std::set <int> ids = cli.getIds ();
 
   if (ids.empty ())
-    throw std::string ("IDs must be specified. See 'timew help tag'.");
-
-  std::vector <std::string> tags;
-  for (auto& arg : cli._args)
   {
-    if (arg.hasTag ("TAG"))
-      tags.push_back (arg.attribute ("raw"));
+    throw std::string ("IDs must be specified. See 'timew help tag'.");
   }
+
+  std::vector<std::string> tags = cli.getTags ();
 
   // Load the data.
   // Note: There is no filter.

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -39,12 +39,6 @@ int CmdTag (
 {
   // Gather IDs and TAGs.
   std::set <int> ids = cli.getIds ();
-
-  if (ids.empty ())
-  {
-    throw std::string ("IDs must be specified. See 'timew help tag'.");
-  }
-
   std::vector<std::string> tags = cli.getTags ();
 
   // Load the data.
@@ -73,6 +67,11 @@ int CmdTag (
 
       dirty = false;
     }
+  }
+
+  if (ids.empty ())
+  {
+    throw std::string ("At least one ID must be specified. See 'timew help tag'.");
   }
 
   // Apply tags to ids.

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -103,7 +103,6 @@ int CmdTag (
     //TODO validate (cli, rules, database, i);
     database.modifyInterval (tracked[tracked.size () - id], i);
 
-    // Feedback.
     if (rules.getBoolean ("verbose"))
     {
       std::cout << "Added " << joinQuotedIfNeeded (" ", tags) << " to @" << id << '\n';

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -41,6 +41,11 @@ int CmdTag (
   std::set <int> ids = cli.getIds ();
   std::vector<std::string> tags = cli.getTags ();
 
+  if (tags.empty ())
+  {
+    throw std::string ("At least one tag must be specified. See 'timew help tag'.");
+  }
+
   // Load the data.
   // Note: There is no filter.
   Interval filter;

--- a/src/commands/CmdUntag.cpp
+++ b/src/commands/CmdUntag.cpp
@@ -39,15 +39,11 @@ int CmdUntag (
 {
   // Gather IDs and TAGs.
   std::set <int> ids = cli.getIds ();
+  std::vector<std::string> tags = cli.getTags ();
 
-  if (ids.empty ())
-    throw std::string ("IDs must be specified. See 'timew help untag'.");
-
-  std::vector <std::string> tags;
-  for (auto& arg : cli._args)
+  if (tags.empty ())
   {
-    if (arg.hasTag ("TAG"))
-      tags.push_back (arg.attribute ("raw"));
+    throw std::string ("At least one tag must be specified. See 'timew help untag'.");
   }
 
   // Load the data.
@@ -78,7 +74,22 @@ int CmdUntag (
     }
   }
 
-  // Apply tags to ids.
+  if (ids.empty ())
+  {
+    if (tracked.empty ())
+    {
+      throw std::string ("There is no active time tracking.");
+    }
+
+    if (!tracked.back ().range.is_open ())
+    {
+      throw std::string ("At least one ID must be specified. See 'timew help tag'.");
+    }
+
+    ids.insert (1);
+  }
+
+  // Remove tags from ids.
   for (auto& id : ids)
   {
     if (id > static_cast <int> (tracked.size ()))

--- a/test/basetest/testing.py
+++ b/test/basetest/testing.py
@@ -13,19 +13,62 @@ class BaseTestCase(unittest.TestCase):
 
 
 class TestCase(BaseTestCase):
-    def assertInterval(self, interval, expectedStart=None, expectedEnd=None, expectedTags=None, description=None):
-        self.assertTrue('start' in interval)
-        self.assertTrue('end' in interval)
+    def assertOpenInterval(self, interval,
+                           expectedStart=None,
+                           expectedTags=None,
+                           description="interval"):
+        self.assertTrue("start" in interval, "{} does not contain a start date".format(description))
+        self.assertFalse("end" in interval, "{} does contain an end date".format(description))
 
+        return self.assertInterval(interval,
+                                   expectedStart=expectedStart,
+                                   expectedEnd=None,
+                                   expectedTags=expectedTags,
+                                   description=description)
+
+    def assertClosedInterval(self, interval,
+                             expectedStart=None,
+                             expectedEnd=None,
+                             expectedTags=None,
+                             description="interval"):
+        self.assertTrue("start" in interval, "{} does not contain a start date".format(description))
+        self.assertTrue("end" in interval, "{} does not contain an end date".format(description))
+
+        return self.assertInterval(interval,
+                                   expectedStart=expectedStart,
+                                   expectedEnd=expectedEnd,
+                                   expectedTags=expectedTags,
+                                   description=description)
+
+    def assertInterval(self, interval,
+                       expectedStart=None,
+                       expectedEnd=None,
+                       expectedTags=None,
+                       description="interval"):
         if expectedStart:
-            self.assertEqual(interval['start'], expectedStart, description)
+            self.assertEqual(
+                interval["start"],
+                expectedStart,
+                "start time of {} does not match (expected: {}, actual: {})".format(description,
+                                                                                    expectedStart,
+                                                                                    interval["start"]))
 
         if expectedEnd:
-            self.assertEqual(interval['end'], expectedEnd, description)
+            self.assertEqual(
+                interval["end"],
+                expectedEnd,
+                "end time of {} does not match (expected: {}, actual: {})".format(description,
+                                                                                  expectedEnd,
+                                                                                  interval["end"]))
 
         if expectedTags:
-            self.assertTrue('tags' in interval)
-            self.assertEqual(interval['tags'], expectedTags, description)
+            self.assertTrue("tags" in interval)
+            self.assertEqual(
+                interval["tags"],
+                expectedTags,
+                "tags of {} do not match (expected: {}, actual: {})". format(description,
+                                                                             expectedTags,
+                                                                             interval["tags"]))
 
 
 # vim: ai sts=4 et sw=4

--- a/test/delete.t
+++ b/test/delete.t
@@ -116,12 +116,11 @@ class TestDelete(TestCase):
         j = self.t.export()
         print(j)
         self.assertEqual(len(j), 1)
-        self.assertInterval(
-            j[0],
-            '{:%Y%m%dT%H}0000Z'.format(now_utc-timedelta(hours=5)),
-            '{:%Y%m%dT%H}0000Z'.format(now_utc-timedelta(hours=4)),
-            ['foo'],
-            'remaining interval')
+        self.assertClosedInterval(j[0],
+                                  expectedStart='{:%Y%m%dT%H}0000Z'.format(now_utc-timedelta(hours=5)),
+                                  expectedEnd='{:%Y%m%dT%H}0000Z'.format(now_utc-timedelta(hours=4)),
+                                  expectedTags=['foo'],
+                                  description='remaining interval')
 
 
 if __name__ == "__main__":

--- a/test/tag.t
+++ b/test/tag.t
@@ -49,6 +49,13 @@ class TestTag(TestCase):
         code, out, err = self.t("tag @1 foo")
         self.assertIn('Added foo to @1', out)
 
+
+    def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
+        """Missing id on inactive time tracking is an error"""
+        self.t("track yesterday for 1hour")
+        code, out, err = self.t.runError("tag foo")
+        self.assertIn("At least one ID must be specified.", err)
+
     def test_add_tag_to_closed_interval(self):
         """Add a tag to an closed interval"""
         self.t("track yesterday for 1hour")

--- a/test/tag.t
+++ b/test/tag.t
@@ -56,6 +56,12 @@ class TestTag(TestCase):
         code, out, err = self.t.runError("tag foo")
         self.assertIn("At least one ID must be specified.", err)
 
+    def test_should_fail_on_no_tags(self):
+        """No tags is an error"""
+        self.t("track yesterday for 1hour")
+        code, out, err = self.t.runError("tag @1")
+        self.assertIn("At least one tag must be specified.", err)
+
     def test_add_tag_to_closed_interval(self):
         """Add a tag to an closed interval"""
         self.t("track yesterday for 1hour")

--- a/test/tag.t
+++ b/test/tag.t
@@ -49,6 +49,17 @@ class TestTag(TestCase):
         code, out, err = self.t("tag @1 foo")
         self.assertIn('Added foo to @1', out)
 
+    def test_should_use_default_on_missing_id_and_active_time_tracking(self):
+        """Use open interval on missing id and active time tracking"""
+        self.t("track yesterday for 1hour foo")
+        self.t("start 30min ago bar")
+        code, out, err = self.t("tag baz")
+        self.assertIn("Added baz to @1", out)
+
+    def test_should_fail_on_missing_id_and_empty_database(self):
+        """Missing id on empty database is an error"""
+        code, out, err = self.t.runError("tag foo")
+        self.assertIn("There is no active time tracking.", err)
 
     def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
         """Missing id on inactive time tracking is an error"""

--- a/test/untag.t
+++ b/test/untag.t
@@ -38,99 +38,99 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from basetest import Timew, TestCase
 
 
-class TestTag(TestCase):
+class TestUntag(TestCase):
     def setUp(self):
         """Executed before each test in the class"""
         self.t = Timew()
 
-    def test_add_tag_to_open_interval(self):
-        """Add a tag to an open interval"""
-        self.t("start 30min ago")
-        code, out, err = self.t("tag @1 foo")
-        self.assertIn("Added foo to @1", out)
+    def test_remove_tag_from_open_interval(self):
+        """Remove a tag from an open interval"""
+        self.t("start 30min ago foo bar baz")
+        code, out, err = self.t("untag @1 foo")
+        self.assertIn('Removed foo from @1', out)
 
         j = self.t.export()
-        self.assertOpenInterval(j[0], expectedTags=["foo"])
+        self.assertOpenInterval(j[0], expectedTags=["bar", "baz"])
 
     def test_should_use_default_on_missing_id_and_active_time_tracking(self):
-        """Use open interval when adding tags with missing id and active time tracking"""
+        """Use open interval when removing tags with missing id and active time tracking"""
         self.t("track yesterday for 1hour foo")
-        self.t("start 30min ago bar")
-        code, out, err = self.t("tag baz")
-        self.assertIn("Added baz to @1", out)
+        self.t("start 30min ago bar baz")
+        code, out, err = self.t("untag baz")
+        self.assertIn("Removed baz from @1", out)
 
         j = self.t.export()
         self.assertClosedInterval(j[0], expectedTags=["foo"])
-        self.assertOpenInterval(j[1], expectedTags=["bar", "baz"])
+        self.assertOpenInterval(j[1], expectedTags=["bar"])
 
     def test_should_fail_on_missing_id_and_empty_database(self):
-        """Adding tag with missing id on empty database is an error"""
-        code, out, err = self.t.runError("tag foo")
+        """Removing tag with missing id on empty database is an error"""
+        code, out, err = self.t.runError("untag foo")
         self.assertIn("There is no active time tracking.", err)
 
     def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
-        """Adding tag with missing id on inactive time tracking is an error"""
+        """Removing tag with missing id on inactive time tracking is an error"""
         self.t("track yesterday for 1hour")
-        code, out, err = self.t.runError("tag foo")
+        code, out, err = self.t.runError("untag foo")
         self.assertIn("At least one ID must be specified.", err)
 
     def test_should_fail_on_no_tags(self):
-        """Calling command 'tag' without tags is an error"""
+        """Calling command 'untag' without tags is an error"""
         self.t("track yesterday for 1hour")
-        code, out, err = self.t.runError("tag @1")
+        code, out, err = self.t.runError("untag @1")
         self.assertIn("At least one tag must be specified.", err)
 
-    def test_add_tag_to_closed_interval(self):
-        """Add a tag to an closed interval"""
-        self.t("track yesterday for 1hour")
-        code, out, err = self.t("tag @1 foo")
-        self.assertIn("Added foo to @1", out)
+    def test_remove_tag_from_closed_interval(self):
+        """Remove a tag from a closed interval"""
+        self.t("track yesterday for 1hour foo bar baz")
+        code, out, err = self.t("untag @1 foo")
+        self.assertIn('Removed foo from @1', out)
 
         j = self.t.export()
-        self.assertClosedInterval(j[0], expectedTags=["foo"])
+        self.assertClosedInterval(j[0], expectedTags=["bar", "baz"])
 
-    def test_add_tags_to_open_interval(self):
-        """Add tags to an open interval"""
-        self.t("start 30min ago")
-        code, out, err = self.t("tag @1 foo bar")
-        self.assertIn("Added foo bar to @1", out)
-
-        j = self.t.export()
-        self.assertOpenInterval(j[0], expectedTags=["bar", "foo"])
-
-    def test_add_tags_to_closed_interval(self):
-        """Add tags to an closed interval"""
-        self.t("track yesterday for 1hour")
-        code, out, err = self.t("tag @1 foo bar")
-        self.assertIn("Added foo bar to @1", out)
+    def test_remove_tags_from_open_interval(self):
+        """Remove tags from an open interval"""
+        self.t("start 30min ago foo bar baz")
+        code, out, err = self.t("untag @1 foo bar")
+        self.assertIn('Removed foo bar from @1', out)
 
         j = self.t.export()
-        self.assertClosedInterval(j[0], expectedTags=["bar", "foo"])
+        self.assertOpenInterval(j[0], expectedTags=["baz"])
 
-    def test_add_tag_to_multiple_intervals(self):
-        """Add a tag to multiple intervals"""
-        self.t("track 2016-01-01T00:00:00 - 2016-01-01T01:00:00 one")
-        self.t("track 2016-01-01T01:00:00 - 2016-01-01T02:00:00 two")
-        code, out, err = self.t("tag @1 @2 foo")
-        self.assertIn("Added foo to @1\nAdded foo to @2", out)
-
-        j = self.t.export()
-        self.assertClosedInterval(j[0], expectedTags=["foo", "one"])
-        self.assertClosedInterval(j[1], expectedTags=["foo", "two"])
-
-    def test_add_tags_to_multiple_intervals(self):
-        """Add tags to multiple intervals"""
-        self.t("track 2016-01-01T00:00:00 - 2016-01-01T01:00:00 one")
-        self.t("track 2016-01-01T01:00:00 - 2016-01-01T02:00:00 two")
-        code, out, err = self.t("tag @1 @2 foo bar")
-        self.assertIn('Added foo bar to @1\nAdded foo bar to @2', out)
+    def test_remove_tags_from_closed_interval(self):
+        """Remove tags from an closed interval"""
+        self.t("track yesterday for 1hour foo bar baz")
+        code, out, err = self.t("untag @1 foo bar")
+        self.assertIn('Removed foo bar from @1', out)
 
         j = self.t.export()
-        self.assertClosedInterval(j[0], expectedTags=["bar", "foo", "one"])
-        self.assertClosedInterval(j[1], expectedTags=["bar", "foo", "two"])
+        self.assertClosedInterval(j[0], expectedTags=["baz"])
 
-    def test_tag_synthetic_interval(self):
-        """Tag a synthetic interval."""
+    def test_remove_tag_from_multiple_intervals(self):
+        """Remove a tag from multiple intervals"""
+        self.t("track 2016-01-01T00:00:00 - 2016-01-01T01:00:00 foo bar one")
+        self.t("track 2016-01-01T01:00:00 - 2016-01-01T02:00:00 foo bar two")
+        code, out, err = self.t("untag @1 @2 foo")
+        self.assertIn('Removed foo from @1\nRemoved foo from @2', out)
+
+        j = self.t.export()
+        self.assertClosedInterval(j[0], expectedTags=["bar", "one"])
+        self.assertClosedInterval(j[1], expectedTags=["bar", "two"])
+
+    def test_remove_tags_from_multiple_intervals(self):
+        """Remove tags from multiple intervals"""
+        self.t("track 2016-01-01T00:00:00 - 2016-01-01T01:00:00 foo bar one")
+        self.t("track 2016-01-01T01:00:00 - 2016-01-01T02:00:00 foo bar two")
+        code, out, err = self.t("untag @1 @2 foo bar")
+        self.assertIn('Removed foo bar from @1\nRemoved foo bar from @2', out)
+
+        j = self.t.export()
+        self.assertClosedInterval(j[0], expectedTags=["one"])
+        self.assertClosedInterval(j[1], expectedTags=["two"])
+
+    def test_untag_synthetic_interval(self):
+        """Untag a synthetic interval."""
         now = datetime.now()
         now_utc = now.utcnow()
 
@@ -151,9 +151,9 @@ class TestTag(TestCase):
         self.t.config("exclusions.sunday", exclusion)
         self.t.config("exclusions.saturday", exclusion)
 
-        self.t("start {:%Y-%m-%dT%H}:45:00 foo".format(five_hours_before))
+        self.t("start {:%Y-%m-%dT%H}:45:00 foo bar".format(five_hours_before))
 
-        self.t("tag @2 bar")
+        self.t("untag @2 foo")
 
         j = self.t.export()
 
@@ -161,21 +161,21 @@ class TestTag(TestCase):
         self.assertClosedInterval(j[0],
                                   expectedStart="{:%Y%m%dT%H}4500Z".format(now_utc - timedelta(hours=5)),
                                   expectedEnd="{:%Y%m%dT%H}0000Z".format(now_utc - timedelta(hours=4)),
-                                  expectedTags=["bar", "foo"],
+                                  expectedTags=["bar"],
                                   description="modified interval")
         self.assertOpenInterval(j[1],
                                 expectedStart="{:%Y%m%dT%H}0000Z".format(now_utc - timedelta(hours=3)),
-                                expectedTags=["foo"],
+                                expectedTags=["bar", "foo"],
                                 description="unmodified interval")
 
-    def test_tag_with_identical_ids(self):
-        self.t("track 2016-01-01T00:00:00 - 2016-01-01T01:00:00")
-        self.t("tag @1 @1 foo")
+    def test_untag_with_identical_ids(self):
+        self.t("track 2016-01-01T00:00:00 - 2016-01-01T01:00:00 foo bar")
+        self.t("untag @1 @1 foo")
 
         j = self.t.export()
 
         self.assertEquals(len(j), 1)
-        self.assertClosedInterval(j[0], expectedTags=["foo"])
+        self.assertClosedInterval(j[0], expectedTags=["bar"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the ability to add/remove tags to/from the current open interval without stating its id.

Closes #21.