### PR TITLE
CLI: Ensure IDs are non-zero

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -412,9 +412,11 @@ void CLI::identifyIds ()
       int digits;
       if (pig.skipLiteral ("@")  &&
           pig.getDigits (digits) &&
-          pig.eos ()             &&
-          digits > 0)
+          pig.eos ())
       {
+        if (digits <= 0)
+          throw format ("'@{1}' is not a valid ID.", digits);
+
         a.tag ("ID");
         a.attribute ("value", digits);
       }

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -412,7 +412,8 @@ void CLI::identifyIds ()
       int digits;
       if (pig.skipLiteral ("@")  &&
           pig.getDigits (digits) &&
-          pig.eos ())
+          pig.eos ()             &&
+          digits > 0)
       {
         a.tag ("ID");
         a.attribute ("value", digits);

--- a/test/ids.t
+++ b/test/ids.t
@@ -50,7 +50,7 @@ class TestIds(TestCase):
 
     def test_should_fail_on_zero_id(self):
         code, out, err = self.t.runError("delete @0")
-        self.assertIn("IDs must be specified.", err)
+        self.assertIn("'@0' is not a valid ID.", err)
 
 
 if __name__ == "__main__":

--- a/test/ids.t
+++ b/test/ids.t
@@ -48,6 +48,10 @@ class TestIds(TestCase):
         self.assertIn(' @1 ', out)
         self.assertIn(' @2 ', out)
 
+    def test_should_fail_on_zero_id(self):
+        code, out, err = self.t.runError("delete @0")
+        self.assertIn("IDs must be specified.", err)
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
This fixes out-of-bounds accesses in several subcommands when the invalid ID `@0` is passed to the program.