### PR TITLE
CmdSummary: Do not extend end time beyond end of day

### DIFF
--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -126,7 +126,7 @@ int CmdSummary (
 
       // Intersect track with day.
       auto today = day_range.intersect (track.range);
-      if (track.range.is_open () && day <= Datetime ())
+      if (track.range.is_open () && day <= Datetime () && today.end > Datetime ())
         today.end = Datetime ();
 
       std::string tags = join(", ", track.tags());


### PR DESCRIPTION
When showing a summary, set the end time to the current time on the last day only. This prevents over-counting of time when a tracked interval covers multiple days.

Fixes test `TestSummary.test_with_open_interval` when the system time is between midnight and 01:00 AM.