### PR TITLE
Add *.pyc files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _CPack_Packages
 CPackConfig.cmake
 CPackSourceConfig.cmake
 *swp
+*.pyc


### PR DESCRIPTION
Running 'make test' generates 'ext/totals.pyc', which should not be under version control.