### PR TITLE
Handle zero-width intervals correctly

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -351,7 +351,10 @@ std::vector <Range> Database::segmentRange (const Range& range)
 
     // Capture date after incrementing month.
     Datetime segmentEnd (start_y, start_m, 1);
-    segments.push_back (Range (segmentStart, segmentEnd));
+    auto segment = Range (segmentStart, segmentEnd);
+    if (range.intersects (segment)) {
+      segments.push_back (segment);
+    }
   }
 
   return segments;

--- a/src/Datafile.cpp
+++ b/src/Datafile.cpp
@@ -90,7 +90,7 @@ std::vector <std::string> Datafile::allLines ()
 void Datafile::addInterval (const Interval& interval)
 {
   // Note: end date might be zero.
-  assert (_range.overlap (interval.range));
+  assert (_range.segmentContains (interval.range));
 
   if (! _lines_loaded)
     load_lines ();
@@ -108,7 +108,7 @@ void Datafile::addInterval (const Interval& interval)
 void Datafile::deleteInterval (const Interval& interval)
 {
   // Note: end date might be zero.
-  assert (_range.overlap (interval.range));
+  assert (_range.segmentContains (interval.range));
 
   if (! _lines_loaded)
     load_lines ();

--- a/src/Range.h
+++ b/src/Range.h
@@ -51,7 +51,9 @@ public:
 
   bool overlap (const Range&) const;
   bool encloses (const Range&) const;
+  bool segmentContains (const Range&) const;
   Range intersect (const Range&) const;
+  bool intersects (const Range&) const;
   Range combine (const Range&) const;
   std::vector <Range> subtract (const Range&) const;
   time_t total () const;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -343,9 +343,11 @@ std::vector <Range> subset (
   const std::vector <Range>& ranges)
 {
   std::vector <Range> all;
-  for (auto& r : ranges)
-    if (range.overlap (r))
+  for (auto& r : ranges) {
+    if (range.intersects (r)) {
       all.push_back (r);
+    }
+  }
 
   return all;
 }
@@ -356,9 +358,11 @@ std::vector <Interval> subset (
   const std::vector <Interval>& intervals)
 {
   std::vector <Interval> all;
-  for (auto& interval : intervals)
-    if (range.overlap (interval.range))
+  for (auto& interval : intervals) {
+    if (range.intersects (interval.range)) {
       all.push_back (interval);
+    }
+  }
 
   return all;
 }
@@ -549,12 +553,8 @@ Range outerRange (const std::vector <Interval>& intervals)
 bool matchesFilter (const Interval& interval, const Interval& filter)
 {
   if ((filter.range.start.toEpoch () == 0 &&
-       filter.range.end.toEpoch () == 0)
-
-      ||
-
-      ((interval.range.end.toEpoch () == 0 || interval.range.end   > filter.range.start) &&
-       (filter.range.end.toEpoch ()   == 0 || interval.range.start < filter.range.end)))
+       filter.range.end.toEpoch () == 0
+     ) || interval.range.intersects (filter.range))
   {
     for (auto& tag : filter.tags ())
       if (! interval.hasTag (tag))
@@ -608,7 +608,7 @@ std::vector <Interval> getTracked (
 
     if (! inclusions.empty ()) {
       auto latest = inclusions.back();
-      if (latest.range.is_open()) {;
+      if (latest.range.is_open()) {
         filter.range.end = 0;
       }
     }

--- a/test/resize.t
+++ b/test/resize.t
@@ -53,6 +53,13 @@ class TestResize(TestCase):
         code, out, err = self.t.runError("resize @1 10mins")
         self.assertIn('Cannot resize open interval @1', err)
 
+    def test_resize_full_month_interval(self):
+        """Resize an interval to cover a full month"""
+        self.t("track now - now")
+        self.t("resize @1 1month")
+        code, out, err = self.t("resize @1 1month")
+        self.assertIn('Resized @1 to 720:00:00', out)
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner

--- a/test/summary.t
+++ b/test/summary.t
@@ -193,6 +193,18 @@ W10 2017-03-11 Sat @3 FOO  10:00:00 11:00:00 1:00:00
                                                      6:00:00
 """, out)
 
+    def test_with_empty_interval_at_start_of_day(self):
+        """Summary should display empty intervals at midnight"""
+        self.t("track sod - sod")
+        code, out, err = self.t("summary :year")
+        self.assertRegexpMatches(out, """
+Wk  ?Date       Day Tags    ?Start      ?End    Time   Total
+[ -]+
+W\d{1,2} \d{4}-\d{2}-\d{2} .{3}       ?0:00:00 0:00:00 0:00:00 0:00:00
+
+[ ]+0:00:00
+""")
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
This pull request introduces two additional methods, `segmentContains` and `intersects`, that are needed to correctly handle empty intervals.

Fixes #101
Fixes #165
Closes #164