### PR TITLE
Interval: prevent adding empty tags to Interval

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -73,7 +73,7 @@ void Interval::initialize (const std::string& line)
     {
       // Optional <tag> ...
       for (unsigned int i = 2 + offset; i < tokens.size (); ++i)
-        _tags.insert (tokens[i]);
+        tag (tokens[i]);
     }
 
     return;
@@ -105,7 +105,7 @@ std::set <std::string> Interval::tags () const
 ////////////////////////////////////////////////////////////////////////////////
 void Interval::tag (const std::string& tag)
 {
-  if (_tags.find (tag) == _tags.end ())
+  if (! tag.empty ())
     _tags.insert (tag);
 }
 


### PR DESCRIPTION
Fix bug where having an empty tag in an Interval inserts an extra space
into its seriliazed string, causing other operations to be unable to
find the interval and stop/remove/modify/etc it


example
```
$ timew start tag "$empty"
# creates entry
# inc 20180831T234143Z #  tag
#                       ^^ extra space gets inserted
$ timew stop
You cannot overlap intervals. Correct the start/end time, or specify the :adjust hint.
# deleteInterval searchs for a line without the extra space, and becomes unable to remove tag
```

an alternative solution is to escape empty strings (inserting `""` as a tag),
but i think its reasonable to assume an empty tag was not intended, perhaps that could be an option.