### PR TITLE
Fix on-modify.timewarrior hook for tasks with multi line description

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -28,7 +28,6 @@
 import sys
 import json
 import subprocess
-import shlex
 
 # Hook should extract all of the following for use as Timewarrior tags:
 #   UUID
@@ -52,7 +51,7 @@ def extract_timew_tags_from(json_obj):
     if 'tags' in json_obj:
         tags.extend(json_obj['tags'])
 
-    return ' '.join(['"{0}"'.format(tag) for tag in tags]).encode('utf-8').strip()
+    return tags
 
 start_or_stop = ''
 
@@ -67,7 +66,7 @@ elif 'start' not in new and 'start' in old:
 if start_or_stop:
     combined = extract_timew_tags_from(new)
 
-    subprocess.call(shlex.split('timew {0} {1} :yes'.format(start_or_stop, combined)))
+    subprocess.call(['timew', start_or_stop] + combined + [':yes'])
 
 # Modifications to task other than start/stop
 elif 'start' in new and 'start' in old:
@@ -75,5 +74,5 @@ elif 'start' in new and 'start' in old:
     new_combined = extract_timew_tags_from(new)
 
     if old_combined != new_combined:
-        subprocess.call(shlex.split('timew untag @1 {0} :yes'.format(old_combined)))
-        subprocess.call(shlex.split('timew tag @1 {0} :yes'.format(new_combined)))
+        subprocess.call(['timew', 'untag', '@1'] + old_combined + [':yes'])
+        subprocess.call(['timew', 'tag', '@1'] + new_combined + [':yes'])


### PR DESCRIPTION
If the description contained multiple lines, it would be formatted as a
bytes object, including Python's `b""` marker for byte literals and any
newlines.  This would then be passed literally to `timew`, which would
then choke on it, because it would record the newlines in its database.

This patch simply gets rid of the string join/split operations and the
encoding, which solves the issue.

Since we pass arrays instead of strings to `subprocess.call`, we are not
subject to command injection security vulnerabilities.

Fixes: 0b6dbf7e12d30fc791a524501e3483989a092a8c