### PR TITLE
Fix segfaults on join command and invalid tags database.

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -372,8 +372,10 @@ void Database::initializeTagDatabase ()
   {
     auto key = pair.first;
     auto* value = (json::object*) pair.second;
-    auto* number = (json::number*) value->_data["count"];
-
+    auto iter = value->_data.find ("count");
+    if (iter == value->_data.end ())
+      throw format ("Failed to find \"count\" member for tag \"{1}\" in tags database. Database corrupted?", key);
+    auto number = static_cast<json::number *> (iter->second);
     _tagInfoDatabase.add (key, TagInfo {(unsigned int) number->_dvalue});
   }
 }

--- a/src/commands/CmdJoin.cpp
+++ b/src/commands/CmdJoin.cpp
@@ -62,8 +62,8 @@ int CmdJoin (
 
   database.startTransaction ();
 
-  auto first_id  = std::min (*ids.begin (), *ids.end ());
-  auto second_id = std::max (*ids.begin (), *ids.end ());
+  auto first_id  = *ids.begin ();
+  auto second_id = *ids.rbegin ();
 
   Interval first  = tracked[tracked.size () - first_id];
   Interval second = tracked[tracked.size () - second_id];

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -59,7 +59,7 @@ std::string quoteIfNeeded (const std::string& input)
 
   auto quote = input.find ('"');
   auto space = input.find (' ');
-  auto op    = input.find_first_of ("+-/()<^!=~_");
+  auto op    = input.find_first_of ("+-/()<^!=~_%");
 
   if (quote == std::string::npos &&
       space == std::string::npos &&

--- a/test/tag.t
+++ b/test/tag.t
@@ -248,6 +248,13 @@ class TestTag(TestCase):
         self.assertNotIn("Note: 'bar' is a new tag", out)
         self.assertIn("Added bar to @1", out)
 
+    def test_tag_with_percent_sign(self):
+        """Call 'tag' with an embedded percent sign"""
+        code, out, err = self.t("start 'ta%g'")
+        self.assertIn("Note: '\"ta%g\"' is a new tag", out)
+        self.t("stop")
+        self.t("delete @1")
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
Two commits that eliminate segment faults when attempting to join intervals and when the tags database is missing "count" member for a particular tag name.