### PR TITLE
#212: "--help" should show help, not considered to be a tag.

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -445,6 +445,23 @@ void CLI::canonicalizeNames ()
       alreadyFoundCmd = true;
     }
 
+    // 'timew <command> --help' should be treated the same as 'timew help
+    // <command>'. Therefore, "--help" on the command line should always
+    // become the command.
+    else if (alreadyFoundCmd && (raw == "--help"))
+    {
+      for (auto& b : _args) {
+        if (b.hasTag("CMD"))
+        {
+          b.unTag("CMD");
+          break;
+        }
+      }
+
+      a.tag ("CMD");
+      a.attribute("canonical", canonical);
+    }
+
     // Hints.
     else if (exactMatch ("hint", raw) ||
              canonicalize (canonical, "hint", raw))

--- a/test/help.t
+++ b/test/help.t
@@ -1,0 +1,54 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Copyright 2006 - 2019, Thomas Lauf, Paul Beckingham, Federico Hernandez.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# https://www.opensource.org/licenses/mit-license.php
+#
+###############################################################################
+
+import os
+import sys
+import unittest
+
+# Ensure python finds the local simpletap module
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from basetest import Timew, TestCase
+
+class TestHelp(TestCase):
+    def setUp(self):
+        """Executed before each test in the class"""
+        self.t = Timew()
+
+    def test_help(self):
+        """Check that 'track --help' is the same is 'help track'"""
+        code, out1, err1 = self.t("help track")
+        code, out2, err2 = self.t("track --help")
+        self.assertEquals(out1, out2)
+
+if __name__ == "__main__":
+    from simpletap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())
+
+# vim: ai sts=4 et sw=4 ft=python


### PR DESCRIPTION
This change makes any instance of '--help' on the command line to be made the
command for this particular invocation.

Also note, this isn't something I hit very often but just wanted to take the opportunity to use the issue to learn another part of the code since I use timewarrrior every day.