### PR TITLE
on-modify.timewarrior: Fix "from __future__ imports must occur at the beginning of the file"

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -25,12 +25,12 @@
 #
 ###############################################################################
 
+from __future__ import print_function
+
 import sys
 import json
 import subprocess
 import shlex
-
-from __future__ import print_function
 
 # Hook should extract all of the following for use as Timewarrior tags:
 #   UUID


### PR DESCRIPTION
Fixes the following error with Python 3.6.8:
```
  File "$HOME/.task/hooks/on-modify.timewarrior", line 33                                                                                                                                                                                                                                                                                                                    
    from __future__ import print_function                                                                                                                                                                                                                                                                                           
SyntaxError: from __future__ imports must occur at the beginning of the file
```