### PR TITLE
on-modify.timewarrior: Fix timewarrior tags being encoded as byte arrays instead of strings

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -54,7 +54,7 @@ def extract_timew_tags_from(json_obj):
     if 'tags' in json_obj:
         tags.extend(json_obj['tags'])
 
-    return ' '.join(['"{0}"'.format(tag) for tag in tags]).encode('utf-8').strip()
+    return ' '.join(['"{0}"'.format(tag) for tag in tags]).encode('utf-8').strip().decode()
 
 start_or_stop = ''
 


### PR DESCRIPTION
This prevents an issue where timewarrior would be `Tracking "b\"...\""` with Python 3.6.8