### PR TITLE
on-modify.timewarrior: Use JIRA task ID as a tag, if present

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -48,6 +48,9 @@ def extract_timew_tags_from(json_obj):
     # Extract attributes for use as tags.
     tags = [json_obj['description']]
 
+    if 'jiraid' in json_obj:
+        tags.append(json_obj['jiraid'])
+        
     if 'project' in json_obj:
         tags.append(json_obj['project'])
 


### PR DESCRIPTION
If the task was imported from JIRA using bugwarrior, use the JIRA task ID as an additional tag.