### PR TITLE
on-modify.timewarrior: Use last annotation as additional tag, if present

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -54,6 +54,9 @@ def extract_timew_tags_from(json_obj):
     if 'tags' in json_obj:
         tags.extend(json_obj['tags'])
 
+    if 'annotations' in json_obj:
+        tags.append(json_obj['annotations'][-1]['description'])
+
     return ' '.join(['"{0}"'.format(tag) for tag in tags]).encode('utf-8').strip()
 
 start_or_stop = ''


### PR DESCRIPTION
This allows the following workflow to be effective and tracked in a useful manner:
```
task 123 start First draft
task 123 stop
...
task 123 start Second iteration
task 123 stop
...
task 123 start Bugfixing
task 123 stop
...
```

This will be tracked as:
```
01:00 - 02:00 <TASK 123 TAGS> "First draft"
03:00 - 04:00 <TASK 123 TAGS> "Second iteration"
05:00 - 06:00 <TASK 123 TAGS> "Bugfixing"
```