### PR TITLE
on-modify.timewarrior: Deal with non-UTF-8 characters in input data from taskwarrior

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -40,8 +40,8 @@ from __future__ import print_function
 #   UDAs
 
 # Make no changes to the task, simply observe.
-old = json.loads(sys.stdin.readline())
-new = json.loads(sys.stdin.readline())
+old = json.loads(sys.stdin.buffer.readline().decode("utf-8", errors="replace"))
+new = json.loads(sys.stdin.buffer.readline().decode("utf-8", errors="replace"))
 print(json.dumps(new))
 
 def extract_timew_tags_from(json_obj):


### PR DESCRIPTION
When input data from taskwarrior (e.g. via bugwarrior) contains UTF-8-illegal characters, `on-modify.timewarrior` would fail:
```
Traceback (most recent call last):
  File "$HOME/.task/hooks/on-modify.timewarrior", line 42, in <module>
    old = json.loads(sys.stdin.readline())
  File "/usr/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 1042: invalid continuation byte
```

This is fixed by manually decoding from stdin's underlying binary I/O object and replacing encoding errors with the Unicode replacement character [1].

[1]: https://docs.python.org/3/library/codecs.html#error-handlers