### PR TITLE
Fix the order of line 33 in on-modify.timewarrior

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -25,12 +25,12 @@
 #
 ###############################################################################
 
+from __future__ import print_function
 import sys
 import json
 import subprocess
 import shlex
 
-from __future__ import print_function
 
 # Hook should extract all of the following for use as Timewarrior tags:
 #   UUID


### PR DESCRIPTION
The import statement in line 33 in the on-modify.timewarrior hook script stopped taskwarrior from modifying any task because the import statement was not at the beginning of the hook script. This pull request fixes the order of line 33 in the on-modify.timewarrior hook script which causes the following error:
 
```
$ task 81 modify add
Modifying task 81 'add'.
  File "/home/user/.task/hooks/on-modify.timewarrior", line 33
    from __future__ import print_function
SyntaxError: from __future__ imports must occur at the beginning of the file
Hook Error: Expected feedback from a failing hook script.
```