### PR TITLE
Allow continue by tag.

### DIFF
--- a/src/commands/CmdContinue.cpp
+++ b/src/commands/CmdContinue.cpp
@@ -38,7 +38,7 @@ int CmdContinue (
 {
   // Gather IDs and TAGs.
   std::set <int> ids = cli.getIds();
-  auto tags = cli.getTags();
+  auto filter = getFilter (cli);
 
   if (ids.size() > 1)
     throw std::string ("You can only specify one ID to continue.");
@@ -50,8 +50,8 @@ int CmdContinue (
   {
     // Load the data.
     // Note: There is no filter.
-    Interval filter;
-    auto tracked = getTracked (database, rules, filter);
+    Interval noFilter;
+    auto tracked = getTracked (database, rules, noFilter);
 
     auto id = *ids.begin ();
 
@@ -60,33 +60,14 @@ int CmdContinue (
 
     to_copy = tracked[tracked.size () - id];
   }
-  else if (!tags.empty())
+  else if (!filter.tags().empty())
   {
-    // Load the data.
-    // Note: There is no filter.
-    Interval filter;
     auto tracked = getTracked (database, rules, filter);
 
-    for (int i = tracked.size() -1; i >= 0; --i)
-    {
-      bool allTagsFound = true;
-      for (unsigned int t = 0; t < tags.size(); ++t)
-      {
-        if (!tracked[i].hasTag(tags[t]))
-        {
-            allTagsFound = false;
-          break;
-        }
-      }
-      if (allTagsFound)
-      {
-        to_copy = tracked[i];
-        break;
-      }
-    }
+    if (tracked.empty())
+      throw format ("Tags '{1}' do not correspond to any tracking.", joinQuotedIfNeeded (", ", filter.tags()));
 
-    if (to_copy.empty())
-      throw format ("Tags '{1}' do not correspond to any tracking.", joinQuotedIfNeeded (", ", tags));
+      to_copy = tracked[0];
   }
   else
   {
@@ -99,7 +80,6 @@ int CmdContinue (
     to_copy = latest;
   }
 
-  auto filter = getFilter (cli);
   Datetime start_time;
   Datetime end_time;
 

--- a/src/commands/CmdContinue.cpp
+++ b/src/commands/CmdContinue.cpp
@@ -38,6 +38,7 @@ int CmdContinue (
 {
   // Gather IDs and TAGs.
   std::set <int> ids = cli.getIds();
+  auto tags = cli.getTags();
 
   if (ids.size() > 1)
     throw std::string ("You can only specify one ID to continue.");
@@ -58,6 +59,34 @@ int CmdContinue (
       throw format ("ID '@{1}' does not correspond to any tracking.", id);
 
     to_copy = tracked[tracked.size () - id];
+  }
+  else if (!tags.empty())
+  {
+    // Load the data.
+    // Note: There is no filter.
+    Interval filter;
+    auto tracked = getTracked (database, rules, filter);
+
+    for (int i = tracked.size() -1; i >= 0; --i)
+    {
+      bool allTagsFound = true;
+      for (unsigned int t = 0; t < tags.size(); ++t)
+      {
+        if (!tracked[i].hasTag(tags[t]))
+        {
+            allTagsFound = false;
+          break;
+        }
+      }
+      if (allTagsFound)
+      {
+        to_copy = tracked[i];
+        break;
+      }
+    }
+
+    if (to_copy.empty())
+      throw format ("Tags '{1}' do not correspond to any tracking.", joinQuotedIfNeeded (", ", tags));
   }
   else
   {

--- a/test/continue.t
+++ b/test/continue.t
@@ -124,6 +124,21 @@ class TestContinue(TestCase):
         self.assertIn("Recorded FOO\n", out)
         self.assertIn("Tracking BAR FOO\n", out)
 
+    def test_continue_with_one_tag_and_intervals_with_multiple_tags(self):
+        """Verify that 'continue' with one tag works to specify a matching interval^"""
+        code, out, err = self.t("start meeting phone 2h ago")
+        self.assertIn("Tracking meeting phone\n", out)
+
+        code, out, err = self.t("start travel customer 1h ago")
+        self.assertIn("Tracking customer travel\n", out)
+
+        code, out, err = self.t("start training travel 30min ago")
+        self.assertIn("Tracking training travel\n", out)
+
+        code, out, err = self.t("continue customer")
+        self.assertIn("Recorded training travel\n", out)
+        self.assertIn("Tracking customer travel\n", out)
+
     def test_continue_with_invalid_tag(self):
         """Verify that 'continue' with invalid tag is an error"""
         code, out, err = self.t("start FOO 1h ago")
@@ -159,6 +174,32 @@ class TestContinue(TestCase):
 
         code, out, err = self.t("continue FOO")
         self.assertIn("Recorded BAR\n", out)
+        self.assertIn("Tracking FOO\n", out)
+
+    def test_continue_with_tag_with_active_tracking(self):
+        """Verify that continuing a specified interval stops active tracking"""
+        code, out, err = self.t("start FOO 1h ago")
+        self.assertIn("Tracking FOO\n", out)
+
+        code, out, err = self.t("start BAR 30min ago")
+        self.assertIn("Tracking BAR\n", out)
+
+        code, out, err = self.t("continue FOO")
+        self.assertIn("Recorded BAR\n", out)
+        self.assertIn("Tracking FOO\n", out)
+
+    def test_continue_with_tag_and_id_continues_interval_with_id(self):
+        """Verify that continuing an interval by specifying its id and some tags works"""
+        code, out, err = self.t("start FOO 1h ago")
+        self.assertIn("Tracking FOO\n", out)
+
+        code, out, err = self.t("start BAR 30min ago")
+        self.assertIn("Tracking BAR\n", out)
+
+        code, out, err = self.t("stop 15min ago")
+        self.assertIn("Recorded BAR\n", out)
+
+        code, out, err = self.t("continue @2 FOO")
         self.assertIn("Tracking FOO\n", out)
 
     def test_continue_with_id_and_date(self):

--- a/test/continue.t
+++ b/test/continue.t
@@ -109,6 +109,58 @@ class TestContinue(TestCase):
         self.assertIn("Recorded BAR\n", out)
         self.assertIn("Tracking FOO\n", out)
 
+    def test_continue_with_multiple_tags(self):
+        """Verify that 'continue' with multiple tags works"""
+        code, out, err = self.t("start FOO BAR 2h ago")
+        self.assertIn("Tracking BAR FOO\n", out)
+
+        code, out, err = self.t("start BAR 1h ago")
+        self.assertIn("Tracking BAR\n", out)
+
+        code, out, err = self.t("start FOO 30min ago")
+        self.assertIn("Tracking FOO\n", out)
+
+        code, out, err = self.t("continue FOO BAR")
+        self.assertIn("Recorded FOO\n", out)
+        self.assertIn("Tracking BAR FOO\n", out)
+
+    def test_continue_with_invalid_tag(self):
+        """Verify that 'continue' with invalid tag is an error"""
+        code, out, err = self.t("start FOO 1h ago")
+        self.assertIn("Tracking FOO\n", out)
+
+        code, out, err = self.t("stop 30min ago")
+        self.assertIn("Recorded FOO\n", out)
+
+        code, out, err = self.t.runError("continue BAR")
+        self.assertIn("Tags 'BAR' do not correspond to any tracking.\n", err)
+
+    def test_continue_with_tag_without_active_tracking(self):
+        """Verify that continuing a specified interval works"""
+        code, out, err = self.t("start FOO 1h ago")
+        self.assertIn("Tracking FOO\n", out)
+
+        code, out, err = self.t("start BAR 30min ago")
+        self.assertIn("Tracking BAR\n", out)
+
+        code, out, err = self.t("stop 15min ago")
+        self.assertIn("Recorded BAR\n", out)
+
+        code, out, err = self.t("continue FOO")
+        self.assertIn("Tracking FOO\n", out)
+
+    def test_continue_with_tag_with_active_tracking(self):
+        """Verify that continuing a specified interval stops active tracking"""
+        code, out, err = self.t("start FOO 1h ago")
+        self.assertIn("Tracking FOO\n", out)
+
+        code, out, err = self.t("start BAR 30min ago")
+        self.assertIn("Tracking BAR\n", out)
+
+        code, out, err = self.t("continue FOO")
+        self.assertIn("Recorded BAR\n", out)
+        self.assertIn("Tracking FOO\n", out)
+
     def test_continue_with_id_and_date(self):
         """Verify that continuing a specified interval with date continues at given date"""
         now_utc = datetime.now().utcnow()


### PR DESCRIPTION
Hi,

I'm using timewarrior in a way where I switch a lot between small tasks and most of the time remember one of the tags of an interval I'd like to continue. Currently I do something like:

```
$ timew summary :month :ids XYZ
$ timew continue @LAST_ID_FOR_XYZ
```

I'm not sure if I'm the only one so I had a look and found it quite possible to introduce the desired behaviour. Is that code anywhere near acceptable or does it fail a lot of your checks? Please let me know what needs to be improved.

I'd like to see that included in the next timew release. (btw is that planned?)

Do you need an issue for that or is the merge request sufficient? If you'd accept the behavior I can surely adopt the documentation, too.