### PR TITLE
Fix calculation of totals longer than a day

### DIFF
--- a/ext/totals.py
+++ b/ext/totals.py
@@ -133,13 +133,15 @@ def calculate_totals(input_stream):
     # Compose table rows.
     grand_total = 0
     for tag in sorted(totals):
-        formatted = format_seconds(totals[tag].seconds)
-        grand_total += totals[tag].seconds
+        seconds = int(totals[tag].total_seconds())
+        formatted = format_seconds(seconds)
+        grand_total += seconds
         output.append("{:{width}} {:10}".format(tag, formatted, width=max_width))
 
     if untagged is not None:
-        formatted = format_seconds(untagged.seconds)
-        grand_total += untagged.seconds
+        seconds = int(untagged.total_seconds())
+        formatted = format_seconds(seconds)
+        grand_total += seconds
         output.append("{:{width}} {:10}".format("", formatted, width=max_width))
 
     # Compose total.

--- a/test/test_totals.t
+++ b/test/test_totals.t
@@ -89,6 +89,39 @@ class TestTotals(TestCase):
             ],
             out)
 
+    def test_totals_with_time_delta_larger_than_24_hours(self):
+        """totals extension should print report for time delta larger than 24 hours"""
+        now = datetime.datetime.now()
+        two_days_before = now - datetime.timedelta(days=2)
+
+        now_utc = now.utcnow()
+        two_days_before_utc = now_utc - datetime.timedelta(days=2)
+
+        input_stream = [
+            'color: off\n',
+            'debug: on\n',
+            'temp.report.start: {:%Y%m%dT%H%M%S}Z\n'.format(two_days_before_utc),
+            'temp.report.end: {:%Y%m%dT%H%M%S}Z\n'.format(now_utc),
+            '\n',
+            '[{{"start":"{:%Y%m%dT%H%M%S}Z","end":"{:%Y%m%dT%H%M%S}Z","tags":["foo"]}}]'.format(two_days_before_utc, now_utc)
+        ]
+
+        out = calculate_totals(input_stream)
+
+        self.assertEqual(
+            [
+                '',
+                'Total by Tag, for {:%Y-%m-%d %H:%M:%S} - {:%Y-%m-%d %H:%M:%S}'.format(two_days_before, now),
+                '',
+                'Tag        Total',
+                '----- ----------',
+                'foo     48:00:00',
+                '      ----------',
+                'Total   48:00:00',
+                '',
+            ],
+            out)
+
     def test_totals_with_emtpy_range(self):
         """totals extension should report error on emtpy range"""
         now = datetime.datetime.now()


### PR DESCRIPTION
The report of the totals extension loses time if the tracked intervals for a tag sum up to more than 24 hours.

datetime.timedelta stores days, seconds and microseconds. Therefore the seconds attribute only stores timedeltas of less than 24 hours. Use total_seconds() instead which properly accounts for the days part.