### PR TITLE
Do not load entire database for all commands

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -261,6 +261,12 @@ std::vector <std::string> Database::files () const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+std::set <std::string> Database::tags () const
+{
+  return _tagInfoDatabase.tags ();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Return most recent line from database 
 std::string Database::firstLine ()
 {

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -434,6 +434,11 @@ std::vector <Range> Database::segmentRange (const Range& range)
   return segments;
 }
 
+bool Database::empty ()
+{
+  return Database::begin () == Database::end ();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 void Database::initializeTagDatabase ()
 {

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -284,8 +284,9 @@ std::string Database::firstLine ()
 ////////////////////////////////////////////////////////////////////////////////
 void Database::addInterval (const Interval& interval, bool verbose)
 {
-  auto tags = interval.tags ();
+  assert ( (interval.end == 0) || (interval.start <= interval.end));
 
+  auto tags = interval.tags ();
   for (auto& tag : tags)
   {
     if (_tagInfoDatabase.incrementTag (tag) == -1 && verbose)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -265,26 +265,6 @@ std::string Database::lastLine ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::vector <std::string> Database::allLines ()
-{
-  if (_files.empty ())
-  {
-    initializeDatafiles ();
-  }
-
-  std::vector <std::string> all;
-  for (auto& file : _files)
-  {
-    auto i = file.allLines ();
-    all.insert (all.end (),
-                std::make_move_iterator (i.begin ()),
-                std::make_move_iterator (i.end ()));
-  }
-
-  return all;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 void Database::addInterval (const Interval& interval, bool verbose)
 {
   auto tags = interval.tags ();

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -253,20 +253,12 @@ std::vector <std::string> Database::files () const
 // Walk backwards through the files until an interval is found.
 std::string Database::lastLine ()
 {
-  if (_files.empty ())
-  {
-    initializeDatafiles ();
-  }
+  auto it = rbegin ();
+  auto end = rend ();
 
-  std::vector <Datafile>::reverse_iterator ri;
-  for (ri = _files.rbegin (); ri != _files.rend (); ri++)
-  {
-    auto line = ri->lastLine ();
-    if (! line.empty ())
-    {
-      return line;
-    }
-  }
+  while (it != end)
+    if (! it->empty ())
+      return *it;
 
   return "";
 }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -28,6 +28,7 @@
 #include <Database.h>
 #include <format.h>
 #include <JSON.h>
+#include <IntervalFactory.h>
 #include <iostream>
 #include <iomanip>
 #include <shared.h>
@@ -443,17 +444,17 @@ void Database::initializeTagDatabase ()
 
   if (!File::read (_location + "/tags.data", content))
   {
-    auto intervals = getAllInclusions (*this);
-
-    if (intervals.empty ())
-    {
+    auto it = rbegin ();
+    auto end = rend ();
+    
+    if (it == end)
       return;
-    }
 
     std::cout << "Tag info database does not exist. Recreating from interval data..." << std::endl  ;
 
-    for (auto& interval : intervals)
+    for (; it != end; ++it)
     {
+      Interval interval = IntervalFactory::fromSerialization (*it);
       for (auto& tag : interval.tags ())
       {
         _tagInfoDatabase.incrementTag (tag);

--- a/src/Database.h
+++ b/src/Database.h
@@ -99,7 +99,6 @@ public:
   std::vector <std::string> files () const;
 
   std::string lastLine ();
-  std::vector <std::string> allLines ();
 
   void addInterval (const Interval&, bool verbose);
   void deleteInterval (const Interval&);

--- a/src/Database.h
+++ b/src/Database.h
@@ -107,6 +107,7 @@ public:
 
   std::string dump () const;
 
+  bool empty ();
   iterator begin ();
   iterator end ();
   reverse_iterator rbegin ();

--- a/src/Database.h
+++ b/src/Database.h
@@ -39,6 +39,60 @@
 class Database
 {
 public:
+
+  class iterator
+  {
+  private:
+    friend class Database;
+    typedef std::vector <Datafile>::iterator files_iterator;
+    typedef std::vector <std::string>::const_iterator lines_iterator;
+    typedef std::string value_type;
+
+    files_iterator files_it;
+    files_iterator files_end;
+
+    lines_iterator lines_it;
+    lines_iterator lines_end;
+
+    iterator (files_iterator fbegin, files_iterator fend);
+
+  public:
+    iterator& operator++ ();
+    iterator& operator++ (int);
+    iterator& operator-- ();
+    bool operator== (const iterator & other) const;
+    bool operator!= (const iterator & other) const;
+    const value_type& operator* () const;
+    const value_type* operator-> () const;
+  };
+
+  class reverse_iterator
+  {
+  private:
+    friend class Database;
+    typedef std::vector <Datafile>::reverse_iterator files_iterator;
+    typedef std::vector <std::string>::const_reverse_iterator lines_iterator;
+    typedef std::string value_type;
+
+    files_iterator files_it;
+    files_iterator files_end;
+
+    lines_iterator lines_it;
+    lines_iterator lines_end;
+
+    reverse_iterator(files_iterator fbegin, files_iterator fend);
+
+  public:
+    reverse_iterator& operator++ ();
+    reverse_iterator& operator++ (int);
+    reverse_iterator& operator-- ();
+    bool operator== (const reverse_iterator & other) const;
+    bool operator!= (const reverse_iterator & other) const;
+    const value_type& operator* () const;
+    const value_type* operator-> () const;
+  };
+
+public:
   Database () = default;
   void initialize (const std::string&, Journal& journal);
   void commit ();
@@ -52,6 +106,11 @@ public:
   void modifyInterval (const Interval&, const Interval &, bool verbose);
 
   std::string dump () const;
+
+  iterator begin ();
+  iterator end ();
+  reverse_iterator rbegin ();
+  reverse_iterator rend ();
 
 private:
   unsigned int getDatafile (int, int);

--- a/src/Database.h
+++ b/src/Database.h
@@ -44,8 +44,8 @@ public:
   {
   private:
     friend class Database;
-    typedef std::vector <Datafile>::iterator files_iterator;
-    typedef std::vector <std::string>::const_iterator lines_iterator;
+    typedef std::vector <Datafile>::reverse_iterator files_iterator;
+    typedef std::vector <std::string>::const_reverse_iterator lines_iterator;
     typedef std::string value_type;
 
     files_iterator files_it;
@@ -70,8 +70,8 @@ public:
   {
   private:
     friend class Database;
-    typedef std::vector <Datafile>::reverse_iterator files_iterator;
-    typedef std::vector <std::string>::const_reverse_iterator lines_iterator;
+    typedef std::vector <Datafile>::iterator files_iterator;
+    typedef std::vector <std::string>::const_iterator lines_iterator;
     typedef std::string value_type;
 
     files_iterator files_it;
@@ -98,7 +98,7 @@ public:
   void commit ();
   std::vector <std::string> files () const;
 
-  std::string lastLine ();
+  std::string firstLine ();
 
   void addInterval (const Interval&, bool verbose);
   void deleteInterval (const Interval&);

--- a/src/Database.h
+++ b/src/Database.h
@@ -97,6 +97,7 @@ public:
   void initialize (const std::string&, Journal& journal);
   void commit ();
   std::vector <std::string> files () const;
+  std::set <std::string> tags () const;
 
   std::string firstLine ();
 

--- a/src/Datafile.cpp
+++ b/src/Datafile.cpp
@@ -77,7 +77,7 @@ std::string Datafile::lastLine ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::vector <std::string> Datafile::allLines ()
+const std::vector <std::string>& Datafile::allLines ()
 {
   if (! _lines_loaded)
     load_lines ();

--- a/src/Datafile.h
+++ b/src/Datafile.h
@@ -41,7 +41,7 @@ public:
   std::string name () const;
 
   std::string lastLine ();
-  std::vector <std::string> allLines ();
+  const std::vector <std::string>& allLines ();
 
   void addInterval (const Interval&);
   void deleteInterval (const Interval&);

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -35,6 +35,7 @@ class Interval : public Range
 {
 public:
   Interval () = default;
+  Interval (const Datetime& start, const Datetime& end) : Range (start, end) {}
   bool empty () const;
 
   bool hasTag (const std::string&) const;

--- a/src/TagInfoDatabase.cpp
+++ b/src/TagInfoDatabase.cpp
@@ -75,6 +75,21 @@ void TagInfoDatabase::add (const std::string& tag, const TagInfo& tagInfo)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Return the current set of tag names
+//
+std::set <std::string> TagInfoDatabase::tags () const
+{
+  std::set <std::string> tags; 
+
+  for (auto& item : _tagInformation)
+  {
+    tags.insert (item.first);
+  }
+
+  return tags;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 std::string TagInfoDatabase::toJson ()
 {
   std::stringstream json;

--- a/src/TagInfoDatabase.h
+++ b/src/TagInfoDatabase.h
@@ -27,6 +27,7 @@
 #ifndef INCLUDED_TAGINFODATABASE
 #define INCLUDED_TAGINFODATABASE
 
+#include <set>
 #include <string>
 #include <map>
 #include <TagInfo.h>
@@ -38,6 +39,8 @@ public:
   int decrementTag (const std::string&);
 
   void add (const std::string&, const TagInfo&);
+
+  std::set <std::string> tags () const;
 
   std::string toJson ();
 

--- a/src/commands/CmdModify.cpp
+++ b/src/commands/CmdModify.cpp
@@ -61,6 +61,7 @@ int CmdModify (
 
   int id = *ids.begin();
 
+  flattenDatabase (database, rules);
   auto intervals = getIntervalsByIds (database, rules, ids);
   if (intervals.size () == 0)
     throw format ("ID '@{1}' does not correspond to any tracking.", id);

--- a/src/commands/CmdMove.cpp
+++ b/src/commands/CmdMove.cpp
@@ -40,6 +40,7 @@ int CmdMove (
   Journal& journal)
 {
   // Gather ID and TAGs.
+  const bool verbose = rules.getBoolean ("verbose");
   std::set <int> ids = cli.getIds ();
 
   if (ids.size() > 1)
@@ -63,57 +64,47 @@ int CmdMove (
       new_start = arg.attribute ("raw");
   }
 
-  // Load the data.
-  // Note: There is no filter.
-  Interval filter;
-  auto tracked = getTracked (database, rules, filter);
+  std::vector <Interval> intervals = getIntervalsByIds (database, rules, ids);
+  Interval interval = intervals.at (0);
 
-  if (id > static_cast <int> (tracked.size ()))
-    throw format ("ID '@{1}' does not correspond to any tracking.", id);
-
-  if (tracked[tracked.size() - id].synthetic)
+  if (interval.synthetic)
   {
-    auto latest = getLatestInterval(database);
-    auto exclusions = getAllExclusions (rules, filter);
-
-    Interval modified {latest};
-
-    // Update database.
-    database.deleteInterval (latest);
-    for (auto& interval : flatten (modified, exclusions))
-      database.addInterval (interval, rules.getBoolean ("verbose"));
+    flattenDatabase (database, rules);
+    intervals = getIntervalsByIds (database, rules, ids);
+    interval = intervals.at (0);
   }
 
   // Move start time.
-  Interval i = tracked[tracked.size () - id];
   Datetime start (new_start);
 
   // Changing the start date should also change the end date by the same
   // amount.
-  if (i.start < start)
+  if (interval.start < start)
   {
-    auto delta = start - i.start;
-    i.start = start;
-    if (! i.is_open ())
-      i.end += delta;
+    auto delta = start - interval.start;
+    interval.start = start;
+    if (! interval.is_open ())
+      interval.end += delta;
   }
   else
   {
-    auto delta = i.start - start;
-    i.start = start;
-    if (! i.is_open ())
-      i.end -= delta;
+    auto delta = interval.start - start;
+    interval.start = start;
+    if (! interval.is_open ())
+      interval.end -= delta;
   }
 
-  database.deleteInterval (tracked[tracked.size () - id]);
+  database.deleteInterval (intervals.at (0));
 
-  validate (cli, rules, database, i);
-  database.addInterval (i, rules.getBoolean ("verbose"));
+  validate (cli, rules, database, interval);
+  database.addInterval (interval, verbose);
 
   journal.endTransaction ();
 
-  if (rules.getBoolean ("verbose"))
-    std::cout << "Moved @" << id << " to " << i.start.toISOLocalExtended () << '\n';
+  if (verbose)
+  {
+    std::cout << "Moved @" << id << " to " << interval.start.toISOLocalExtended () << '\n';
+  }
 
   return 0;
 }

--- a/src/commands/CmdShorten.cpp
+++ b/src/commands/CmdShorten.cpp
@@ -39,6 +39,7 @@ int CmdShorten (
   Database& database,
   Journal& journal)
 {
+  const bool verbose = rules.getBoolean ("verbose");
   std::set <int> ids = cli.getIds ();
 
   if (ids.empty ())
@@ -54,56 +55,31 @@ int CmdShorten (
 
   journal.startTransaction ();
 
-  // Load the data.
-  // Note: There is no filter.
-  Interval filter;
-  auto tracked = getTracked (database, rules, filter);
-
-  bool dirty = true;
-
-  for (auto& id : ids)
-  {
-    if (id > static_cast <int> (tracked.size ()))
-      throw format ("ID '@{1}' does not correspond to any tracking.", id);
-
-    if (tracked[tracked.size() - id].synthetic && dirty)
-    {
-      auto latest = getLatestInterval(database);
-      auto exclusions = getAllExclusions (rules, filter);
-
-      Interval modified {latest};
-
-      // Update database.
-      database.deleteInterval (latest);
-      for (auto& interval : flatten (modified, exclusions))
-        database.addInterval (interval, rules.getBoolean ("verbose"));
-
-      dirty = false;
-    }
-  }
+  flattenDatabase (database, rules);
+  std::vector <Interval> intervals = getIntervalsByIds (database, rules, ids);
 
   // Shorten intervals specified by ids
-  for (auto& id : ids)
+  for (auto& interval : intervals)
   {
-    if (id > static_cast <int> (tracked.size ()))
-      throw format ("ID '@{1}' does not correspond to any tracking.", id);
-
-    Interval i = tracked[tracked.size () - id];
-    if (i.is_open ())
-      throw format ("Cannot shorten open interval @{1}", id);
+    if (interval.is_open ())
+      throw format ("Cannot shorten open interval @{1}", interval.id);
 
     Duration dur (delta);
-    if (dur > (i.end - i.start))
-      throw format ("Cannot shorten interval @{1} by {2} because it is only {3} in length.", id, dur.formatHours (), Duration (i.end - i.start).formatHours ());
+    if (dur > (interval.end - interval.start))
+    {
+      throw format ("Cannot shorten interval @{1} by {2} because it is only {3} in length.",
+                    interval.id, dur.formatHours (),
+                    Duration (interval.end - interval.start).formatHours ());
+    }
 
-    database.deleteInterval (tracked[tracked.size () - id]);
+    database.deleteInterval (interval);
 
-    i.end -= dur.toTime_t ();
-    validate (cli, rules, database, i);
-    database.addInterval (i, rules.getBoolean ("verbose"));
+    interval.end -= dur.toTime_t ();
+    validate (cli, rules, database, interval);
+    database.addInterval (interval, verbose);
 
-    if (rules.getBoolean ("verbose"))
-      std::cout << "Shortened @" << id << " by " << dur.formatHours () << '\n';
+    if (verbose)
+      std::cout << "Shortened @" << interval.id << " by " << dur.formatHours () << '\n';
   }
 
   journal.endTransaction ();

--- a/src/commands/CmdSplit.cpp
+++ b/src/commands/CmdSplit.cpp
@@ -39,25 +39,20 @@ int CmdSplit (
   Database& database,
   Journal& journal)
 {
+  const bool verbose = rules.getBoolean ("verbose");
   std::set <int> ids = cli.getIds ();
 
   if (ids.empty ())
     throw std::string ("IDs must be specified. See 'timew help split'.");
 
-  // Load the data.
-  // Note: There is no filter.
-  Interval filter;
-  auto tracked = getTracked (database, rules, filter);
-
   journal.startTransaction ();
 
-  // Apply tags to ids.
-  for (auto& id : ids)
-  {
-    if (id > static_cast <int> (tracked.size ()))
-      throw format ("ID '@{1}' does not correspond to any tracking.", id);
+  std::vector <Interval> intervals = getIntervalsByIds (database, rules, ids);
 
-    Interval first = tracked[tracked.size () - id];
+  // Apply tags to ids.
+  for (const auto& interval : intervals)
+  {
+    Interval first = interval;
     Interval second = first;
 
     if (first.is_open ())
@@ -75,16 +70,16 @@ int CmdSplit (
       second.start = midpoint;
     }
 
-    database.deleteInterval (tracked[tracked.size () - id]);
+    database.deleteInterval (interval);
 
     validate (cli, rules, database, first);
-    database.addInterval (first, rules.getBoolean ("verbose"));
+    database.addInterval (first, verbose);
 
     validate (cli, rules, database, second);
-    database.addInterval (second, rules.getBoolean ("verbose"));
+    database.addInterval (second, verbose);
 
-    if (rules.getBoolean ("verbose"))
-      std::cout << "Split @" << id << '\n';
+    if (verbose)
+      std::cout << "Split @" << interval.id << '\n';
   }
 
   journal.endTransaction ();

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <cmake.h>
+#include <cassert>
 #include <commands.h>
 #include <format.h>
 #include <timew.h>
@@ -39,6 +40,7 @@ int CmdTag (
   Journal& journal)
 {
   // Gather IDs and TAGs.
+  const bool verbose = rules.getBoolean ("verbose");
   std::set <int> ids = cli.getIds ();
   std::vector<std::string> tags = cli.getTags ();
 
@@ -47,68 +49,43 @@ int CmdTag (
     throw std::string ("At least one tag must be specified. See 'timew help tag'.");
   }
 
-  // Load the data.
-  // Note: There is no filter.
-  Interval filter;
-  auto tracked = getTracked (database, rules, filter);
-
-  bool dirty = true;
-
   journal.startTransaction ();
 
-  for (auto& id : ids)
+  flattenDatabase (database, rules);
+  auto intervals = getIntervalsByIds (database, rules, ids);
+
+  if (intervals.empty ())
   {
-    if (id > static_cast <int> (tracked.size ()))
-      throw format ("ID '@{1}' does not correspond to any tracking.", id);
-
-    if (tracked[tracked.size() - id].synthetic && dirty)
-    {
-      auto latest = getLatestInterval(database);
-      auto exclusions = getAllExclusions (rules, filter);
-
-      Interval modified {latest};
-
-      // Update database.
-      database.deleteInterval (latest);
-      for (auto& interval : flatten (modified, exclusions))
-        database.addInterval (interval, rules.getBoolean ("verbose"));
-
-      dirty = false;
-    }
-  }
-
-  if (ids.empty ())
-  {
-    if (tracked.empty ())
+    if (database.empty ())
     {
       throw std::string ("There is no active time tracking.");
     }
 
-    if (!tracked.back ().is_open ())
+    auto latest = getLatestInterval (database);
+
+    if (!latest.is_open ())
     {
       throw std::string ("At least one ID must be specified. See 'timew help tag'.");
     }
 
-    ids.insert (1);
+    latest.id = 1;
+    intervals.push_back (latest);
   }
 
   // Apply tags to ids.
-  for (auto& id : ids)
+  for (const auto& interval : intervals)
   {
-    if (id > static_cast <int> (tracked.size ()))
-      throw format ("ID '@{1}' does not correspond to any tracking.", id);
-
-    Interval i = tracked[tracked.size () - id];
+    Interval modified {interval};
 
     for (auto& tag : tags)
-      i.tag (tag);
+      modified.tag (tag);
 
     //TODO validate (cli, rules, database, i);
-    database.modifyInterval (tracked[tracked.size () - id], i, rules.getBoolean ("verbose"));
+    database.modifyInterval (interval, modified, verbose);
 
-    if (rules.getBoolean ("verbose"))
+    if (verbose)
     {
-      std::cout << "Added " << joinQuotedIfNeeded (" ", tags) << " to @" << id << '\n';
+      std::cout << "Added " << joinQuotedIfNeeded (" ", tags) << " to @" << interval.id << '\n';
     }
   }
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -312,20 +312,6 @@ std::vector <Range> getAllExclusions (
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::vector <Interval> getAllInclusions (Database& database)
-{
-  std::vector <Interval> all;
-  auto it = database.rbegin ();
-  auto end = database.rend ();
-  for ( ;it != end; ++it)
-  {
-    all.push_back (IntervalFactory::fromSerialization (*it));
-  }
-
-  return all;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 std::vector <Interval> subset (
   const Interval& filter,
   const std::deque <Interval>& intervals)

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -693,17 +693,6 @@ std::vector <Range> getUntracked (
 Interval getLatestInterval (Database& database)
 {
   Interval i;
-  for (auto& line : database.allLines ())
-  {
-    // inc YYYYMMDDTHHMMSSZ - YYYYMMDDTHHMMSSZ # ...
-    //                     ^ 20
-    if (line.find (" - ") != 20)
-    {
-      i = IntervalFactory::fromSerialization (line);
-      return i;
-    }
-  }
-
   auto lastLine = database.lastLine ();
   if (! lastLine.empty ())
     i = IntervalFactory::fromSerialization (lastLine);

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -653,9 +653,24 @@ std::vector <Range> getUntracked (
   const Rules& rules,
   Interval& filter)
 {
+  bool found_match = false;
   std::vector <Range> inclusion_ranges;
-  for (auto& i : subset (filter, getAllInclusions (database)))
-    inclusion_ranges.push_back (i);
+  for (auto& line : database)
+  {
+    Interval i = IntervalFactory::fromSerialization (line);
+    if (matchesFilter (i, filter))
+    {
+      inclusion_ranges.push_back (i);
+      found_match = true;
+    }
+    else if (found_match)
+    {
+      // If we already had a match, and now we do not, since the database is in
+      // order from most recent to oldest inclusion, we can be sure that there
+      // will not be any further matches.
+      break;
+    }
+  }
 
   auto available = subtractRanges ({filter}, getAllExclusions (rules, filter));
   auto untracked = subtractRanges (available, inclusion_ranges);

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -486,31 +486,6 @@ std::vector <Range> subtractRanges (
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// From a set of intervals, find the earliest start and the latest end, and
-// return these in a Range.
-Range outerRange (const std::vector <Interval>& intervals)
-{
-  Range outer;
-  for (auto& interval : intervals)
-  {
-    if (interval.start < outer.start || outer.start.toEpoch () == 0)
-      outer.start = interval.start;
-
-    // Deliberately mixed start/end.
-    if (interval.start > outer.end)
-      outer.end = interval.start;
-
-    if (interval.end > outer.end)
-      outer.end = interval.end;
-
-    if (! interval.is_ended ())
-      outer.end = Datetime ();
-  }
-
-  return outer;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // An interval matches a filter interval if the start/end overlaps, and all
 // filter interval tags are found in the interval.
 //

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -315,7 +315,7 @@ std::vector <Range> getAllExclusions (
 std::vector <Interval> getAllInclusions (Database& database)
 {
   std::vector <Interval> all;
-  for (auto& line : database.allLines ())
+  for (auto& line : database)
   {
     Interval i = IntervalFactory::fromSerialization (line);
     all.push_back (i);

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -315,10 +315,11 @@ std::vector <Range> getAllExclusions (
 std::vector <Interval> getAllInclusions (Database& database)
 {
   std::vector <Interval> all;
-  for (auto& line : database)
+  auto it = database.rbegin ();
+  auto end = database.rend ();
+  for ( ;it != end; ++it)
   {
-    Interval i = IntervalFactory::fromSerialization (line);
-    all.push_back (i);
+    all.push_back (IntervalFactory::fromSerialization (*it));
   }
 
   return all;
@@ -572,8 +573,8 @@ std::vector <Interval> getTracked (
   // Avoid assigning a zero-width range - leave it unstarted instead.
   if (! filter.is_started ())
   {
-    auto begin = database.begin ();
-    auto end = database.end ();
+    auto begin = database.rbegin ();
+    auto end = database.rend ();
     if (begin != end) 
     {
       filter.start = IntervalFactory::fromSerialization (*begin).start;
@@ -588,11 +589,9 @@ std::vector <Interval> getTracked (
   int id_skip = 0;
   std::deque <Interval> intervals;
 
-  auto it = database.rbegin ();
-  auto end = database.rend ();
-  for (; it != end; ++it)
+  for (auto& line : database)
   {
-    Interval interval = IntervalFactory::fromSerialization(*it);
+    Interval interval = IntervalFactory::fromSerialization(line);
 
     // Since we are moving backwards, and the intervals are in sorted order,
     // if the filter is after the interval, we know there will be no more
@@ -668,9 +667,9 @@ std::vector <Range> getUntracked (
 Interval getLatestInterval (Database& database)
 {
   Interval i;
-  auto lastLine = database.lastLine ();
-  if (! lastLine.empty ())
-    i = IntervalFactory::fromSerialization (lastLine);
+  auto firstLine = database.firstLine ();
+  if (! firstLine.empty ())
+    i = IntervalFactory::fromSerialization (firstLine);
 
   return i;
 }

--- a/src/dom.cpp
+++ b/src/dom.cpp
@@ -177,11 +177,8 @@ bool domGet (
 
     else if (pig.skipLiteral ("tag."))
     {
-      // Generate a unique, ordered list of tags.
-      std::set <std::string> tags;
-      for (auto& interval : getAllInclusions (database))
-        for (auto& tag : interval.tags ())
-          tags.insert (tag);
+      // get unique, ordered list of tags.
+      std::set <std::string> tags = database.tags ();
 
       // dom.tag.count
       if (pig.skipLiteral ("count"))

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -446,7 +446,8 @@ std::vector <Interval> getOverlaps (
   const Rules& rules,
   const Interval& interval)
 {
-  Interval range_filter;
+  Interval range_filter {interval.start, interval.end};
+
   auto tracked = getTracked (database, rules, range_filter);
 
   std::vector <Interval> overlaps;

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -87,11 +87,9 @@ std::string intervalSummarize (
     // acceptable definition of "the current task".
     time_t total_recorded = 0;
 
-    auto i = database.rbegin ();
-    auto end = database.rend ();
-    for (; i != end; ++i)
+    for (auto& line : database)
     {
-      Interval current = IntervalFactory::fromSerialization (*i);
+      Interval current = IntervalFactory::fromSerialization (line);
       if (interval.tags () == current.tags ())
         total_recorded += current.total ();
       else

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -30,6 +30,7 @@
 #include <format.h>
 #include <Datetime.h>
 #include <Duration.h>
+#include <IntervalFactory.h>
 #include <sstream>
 #include <iomanip>
 #include <iostream>
@@ -85,13 +86,17 @@ std::string intervalSummarize (
     // in the most recent set of intervals for the same tags. This is the
     // acceptable definition of "the current task".
     time_t total_recorded = 0;
-    auto inclusions = getAllInclusions (database);
-    std::vector <Interval>::reverse_iterator i;
-    for (i = inclusions.rbegin (); i != inclusions.rend (); i++)
-      if (interval.tags () == i->tags ())
-        total_recorded += i->total ();
+
+    auto i = database.rbegin ();
+    auto end = database.rend ();
+    for (; i != end; ++i)
+    {
+      Interval current = IntervalFactory::fromSerialization (*i);
+      if (interval.tags () == current.tags ())
+        total_recorded += current.total ();
       else
         break;
+    }
 
     Duration total (total_recorded);
 

--- a/src/timew.h
+++ b/src/timew.h
@@ -40,7 +40,6 @@
 Interval                getFilter         (const CLI&);
 std::vector <Range>     getHolidays       (const Rules&);
 std::vector <Range>     getAllExclusions  (const Rules&, const Range&);
-std::vector <Interval>  getAllInclusions  (Database&);
 std::vector <Interval>  subset            (const Interval&, const std::vector <Interval>&);
 std::vector <Range>     subset            (const Range&, const std::vector <Range>&);
 std::vector <Interval>  subset            (const Range&, const std::vector <Interval>&);

--- a/src/timew.h
+++ b/src/timew.h
@@ -40,9 +40,11 @@
 Interval                getFilter         (const CLI&);
 std::vector <Range>     getHolidays       (const Rules&);
 std::vector <Range>     getAllExclusions  (const Rules&, const Range&);
+std::vector <Interval>  getIntervalsByIds (Database&, const Rules&, const std::set <int>&);
 std::vector <Interval>  subset            (const Interval&, const std::vector <Interval>&);
 std::vector <Range>     subset            (const Range&, const std::vector <Range>&);
 std::vector <Interval>  subset            (const Range&, const std::vector <Interval>&);
+void                    flattenDatabase   (Database&, const Rules&);
 std::vector <Interval>  flatten           (const Interval&, const std::vector <Range>&);
 std::vector <Range>     merge             (const std::vector <Range>&);
 std::vector <Range>     addRanges         (const Range&, const std::vector <Range>&, const std::vector <Range>&);

--- a/test/modify.t
+++ b/test/modify.t
@@ -166,6 +166,85 @@ class TestModify(TestCase):
         code, out, err = self.t.runError("modify start @1 {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=2)))
         self.assertIn("You cannot overlap intervals", err)
 
+    def test_modify_move_start_of_synthetic_interval(self):
+        """Move the start time of synthetic interval forward."""
+
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        three_hours_before = now - timedelta(hours=3)
+        four_hours_before = now - timedelta(hours=4)
+
+        now_utc = now.utcnow().replace(second=0, microsecond=0, minute=0)
+        day_before = now_utc - timedelta(days=1)
+        three_hours_before_utc = now_utc - timedelta(hours=3)
+        four_hours_before_utc = now_utc - timedelta(hours=4)
+        five_hours_before_utc = now_utc - timedelta(hours=5)
+
+        self.t.configure_exclusions((four_hours_before.time(), three_hours_before.time()))
+
+        # Place a non-synthetic interval in the history
+        self.t("track from {:%Y-%m-%dT%H:%M:%S}Z for 30min bar".format(day_before))
+        self.t("start {:%Y-%m-%dT%H:%M:%S}Z foo".format(five_hours_before_utc))
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 3)
+        self.assertClosedInterval(j[0],
+                                  expectedStart=day_before,
+                                  expectedEnd=day_before + timedelta(minutes=30),
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertClosedInterval(j[1],
+                                  expectedStart=five_hours_before_utc,
+                                  expectedEnd=four_hours_before_utc,
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertOpenInterval(j[2],
+                                expectedStart=three_hours_before_utc,
+                                expectedTags=[],
+                                description="unmodified interval")
+
+        # First move the non-synthetic one
+        self.t("modify start @3 {:%Y-%m-%dT%H:%M:%S}Z".format(day_before - timedelta(minutes=30)))
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 3)
+        self.assertClosedInterval(j[0],
+                                  expectedStart=day_before - timedelta(minutes=30),
+                                  expectedEnd=day_before + timedelta(minutes=30),
+                                  expectedTags=[],
+                                  description="moved interval")
+        self.assertClosedInterval(j[1],
+                                  expectedStart=five_hours_before_utc,
+                                  expectedEnd=four_hours_before_utc,
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertOpenInterval(j[2],
+                                expectedStart=three_hours_before_utc,
+                                expectedTags=[],
+                                description="unmodified interval")
+
+        # Then move the synthetic one
+        self.t("modify start @1 {:%Y-%m-%dT%H:%M:%S}Z".format(three_hours_before_utc + timedelta(minutes=10)))
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 3)
+        self.assertClosedInterval(j[0],
+                                  expectedStart=day_before - timedelta(minutes=30),
+                                  expectedEnd=day_before + timedelta(minutes=30),
+                                  expectedTags=[],
+                                  description="moved interval")
+        self.assertClosedInterval(j[1],
+                                  expectedStart=five_hours_before_utc,
+                                  expectedEnd=four_hours_before_utc,
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertOpenInterval(j[2],
+                                expectedStart=three_hours_before_utc + timedelta(minutes=10),
+                                expectedTags=[],
+                                description="moved interval")
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
 

--- a/test/move.t
+++ b/test/move.t
@@ -133,25 +133,70 @@ class TestMove(TestCase):
         four_hours_before = now - timedelta(hours=4)
 
         now_utc = now.utcnow()
+        day_before = now_utc - timedelta(days=1)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
 
         self.t.configure_exclusions((four_hours_before.time(), three_hours_before.time()))
 
+        # Place a non-synthetic interval in the history
+        self.t("start {:%Y-%m-%dT%H:%M:%S}Z bar".format(day_before))
+        self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(day_before + timedelta(minutes=30)))
+
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z foo".format(five_hours_before_utc))
 
+        j = self.t.export()
+
+        self.assertEqual(len(j), 3)
+        self.assertClosedInterval(j[0],
+                                  expectedStart=day_before,
+                                  expectedEnd=day_before + timedelta(minutes=30),
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertClosedInterval(j[1],
+                                  expectedStart=five_hours_before_utc,
+                                  expectedEnd=four_hours_before_utc,
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertOpenInterval(j[2],
+                                expectedStart=three_hours_before_utc,
+                                expectedTags=[],
+                                description="unmodified interval")
+
+        # First move the non-synthetic one
+        self.t("move @3 {:%Y-%m-%dT%H:%M:%S}Z".format(day_before + timedelta(minutes=30)))
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 3)
+        self.assertClosedInterval(j[0],
+                                  expectedStart=day_before + timedelta(minutes=30),
+                                  expectedEnd=day_before + timedelta(hours=1),
+                                  expectedTags=[],
+                                  description="moved interval")
+        self.assertClosedInterval(j[1],
+                                  expectedStart=five_hours_before_utc,
+                                  expectedEnd=four_hours_before_utc,
+                                  expectedTags=[],
+                                  description="unmodified interval")
+        self.assertOpenInterval(j[2],
+                                expectedStart=three_hours_before_utc,
+                                expectedTags=[],
+                                description="unmodified interval")
+
+        # Then move the synthetic one
         self.t("move @2 {:%Y-%m-%dT%H:%M:%S}Z".format(five_hours_before_utc + timedelta(minutes=20)))
 
         j = self.t.export()
 
-        self.assertEqual(len(j), 2)
-        self.assertClosedInterval(j[0],
+        self.assertEqual(len(j), 3)
+        self.assertClosedInterval(j[1],
                                   expectedStart=five_hours_before_utc + timedelta(minutes=20),
                                   expectedEnd=four_hours_before_utc + timedelta(minutes=20),
                                   expectedTags=[],
                                   description="moved interval")
-        self.assertOpenInterval(j[1],
+        self.assertOpenInterval(j[2],
                                 expectedStart=three_hours_before_utc,
                                 expectedTags=[],
                                 description="unmodified interval")

--- a/test/performance-test.sh
+++ b/test/performance-test.sh
@@ -2,9 +2,23 @@
 
 set -e
 
-THREE_HOURS_BEFORE=$( date -v "-3H" "+%Y%m%dT%H0000" )
-TWO_HOURS_BEFORE=$( date -v "-2H" "+%Y%m%dT%H0000" )
-ONE_HOUR_BEFORE=$( date -v "-1H" "+%Y%m%dT%H0000" )
+# Due to system integrity protection, macOS requires us to use a copy of date
+# if we want it to work with faketimea.
+DATE=$(command -v date)
+if [ $(uname -s) = "Darwin" ]; then
+    TEMP_DATE=$(mktemp)
+    cp $DATE $TEMP_DATE
+    chmod +x $TEMP_DATE
+    DATE=$TEMP_DATE
+    function cleanup {
+        rm -fr $DATE
+    }
+    trap cleanup EXIT
+fi
+
+THREE_HOURS_BEFORE=$( faketime '3 hours ago' ${DATE} "+%Y%m%dT%H0000" )
+TWO_HOURS_BEFORE=$( faketime '2 hours ago' ${DATE} "+%Y%m%dT%H0000" )
+ONE_HOUR_BEFORE=$( faketime '1 hours ago' ${DATE} "+%Y%m%dT%H0000" )
 
 TIMEW_BIN="${BASH_SOURCE[0]%/*}/../src/timew"
 
@@ -314,7 +328,7 @@ for timew_cmd in ${TIMEW_COMMANDS} ; do
 done
 
 for step in $( seq 0 20 ) ; do
-  YEAR_MONTH=$( date -v "-${step}m" "+%Y-%m" )
+  YEAR_MONTH=$( faketime "${step} months ago" ${DATE} "+%Y-%m" )
 
   if [[ "${step}" -gt 0 ]] ; then
     year=${YEAR_MONTH%-*}

--- a/test/simpletap/__init__.py
+++ b/test/simpletap/__init__.py
@@ -145,7 +145,7 @@ class TAPTestResult(unittest.result.TestResult):
         trace = traceback.extract_tb(tb)
         for t in trace:
             # t = (filename, line_number, function_name, raw_line)
-            if t[2].startswith("test"):
+            if t[2].startswith("test_"):
                 trace_msg = " on file {0} line {1} in {2}: '{3}'".format(*t)
                 break
 


### PR DESCRIPTION
This merge request improves the performance when there are many entries in the database by not loading or parsing all the lines in many cases where it is not necessary.

Related to issue #245
