### PR TITLE
Stop with id should suggest modify command

### DIFF
--- a/src/commands/CmdStop.cpp
+++ b/src/commands/CmdStop.cpp
@@ -50,10 +50,16 @@ int CmdStop (
   // Load the most recent interval.
   auto filter = getFilter (cli);
   auto latest = getLatestInterval (database);
+  std::set <int> ids = cli.getIds ();
 
   // Verify the interval is open.
   if (! latest.is_open ())
     throw std::string ("There is no active time tracking.");
+
+  // We either expect no ids, or we're operating on the most current.
+  if (! ids.empty ())
+    throw std::string ("The stop command works on the most recent open interval. "
+                       "Perhaps you want the modify command?.");
 
   journal.startTransaction ();
 

--- a/test/stop.t
+++ b/test/stop.t
@@ -198,6 +198,19 @@ class TestStop(TestCase):
         self.assertEqual(len(j), 1)
         self.assertClosedInterval(j[0])
 
+    def test_stop_with_id(self):
+        """Stop does not work with with ids other than one"""
+        self.t("start 2h ago")
+        self.t("start 1h ago")
+        
+        code, out, err = self.t.runError("stop @1")
+        # If trying to stop an older interval, check that modify was suggested.
+        self.assertIn("modify", err)
+
+        code, out, err = self.t.runError("stop @2")
+        # If trying to stop an older interval, check that modify was suggested.
+        self.assertIn("modify", err)
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
Recently I was trying to stop an interval that I had left open over the
weekend, but I had already started a new interval at the beginning of the
week. The error I was received was "The end of a date range must be after the
start." which was confusing to me.

After a few moments I realized I should have been using the modify command.
Now the stop command will suggest this if someone tries.