### PR TITLE
Report when tests do not run

### DIFF
--- a/test/problems
+++ b/test/problems
@@ -76,34 +76,45 @@ if __name__ == "__main__":
             match = file.match(line)
             if match:
                 filename = match.group(1)
+                continue
 
-            elif expected_fail.match(line):
+            match = expected_fail.match(line)
+            if match:
                 expected[filename] += 1
+                continue
 
-            elif unexpected_pass.match(line):
+            match = unexpected_pass.match(line)
+            if match:
                 unexpected[filename] += 1
+                continue
 
-            elif skip.match(line):
+            match = skip.match(line)
+            if match:
                 skipped[filename] += 1
+                continue
 
             # It's important these come last, since they're subpatterns of the above
 
-            elif ok.match(line):
+            match = ok.match(line)
+            if match:
                 passed[filename] += 1
+                continue
 
-            elif not_ok.match(line):
+            match = not_ok.match(line)
+            if match:
                 errors[filename] += 1
+                continue
 
-            elif comment.match(line):
-                pass
+            match = plan.match(line)
+            if match:
+                continue
 
-            elif plan.match(line):
-                pass
+            match = comment.match(line)
+            if match:
+                continue
 
-            else:
-                # Uncomment if you want to see malformed things we caught as well...
-                # print(color("Malformed TAP (" + filename + "): " + line, "red"))
-                pass
+            # Uncomment if you want to see malformed things we caught as well...
+            # print(color("Malformed TAP (" + filename + "): " + line, "red"))
 
         # Last line contains the ending timestamp
         stop = float(timestamp.match(line).group(1))

--- a/test/problems
+++ b/test/problems
@@ -61,10 +61,13 @@ if __name__ == "__main__":
     ok = re.compile(r"^ok ", re.I)
     not_ok = re.compile(r"^not ok", re.I)
     comment = re.compile(r"^#")
-    plan = re.compile(r"^1..\d+\s*(?:#.*)?$")
+    plan = re.compile(r"^1..(\d+)\s*(?:#.*)?$")
 
     start = None
     stop = None
+    filename = None
+    expected_test_count = 0
+    need_plan = False
 
     with open(cmd_args.tapfile) as fh:
         for line in fh:
@@ -75,22 +78,39 @@ if __name__ == "__main__":
 
             match = file.match(line)
             if match:
+                if filename:
+                    if expected_test_count > 0:
+                        print(color("'{}' failed to run all tests.".format(filename), "red"), file=sys.stderr)
+                        errors[filename] += expected_test_count
+                    elif need_plan:
+                        print(color("'{}' failed to run any tests.".format(filename), "red"), file=sys.stderr)
+                        errors[filename] += 1
                 filename = match.group(1)
+                need_plan = True
+                continue
+
+            match = plan.match(line)
+            if match:
+                expected_test_count = int(match.group(1))
+                need_plan = False
                 continue
 
             match = expected_fail.match(line)
             if match:
                 expected[filename] += 1
+                expected_test_count -= 1
                 continue
 
             match = unexpected_pass.match(line)
             if match:
                 unexpected[filename] += 1
+                expected_test_count -= 1
                 continue
 
             match = skip.match(line)
             if match:
                 skipped[filename] += 1
+                expected_test_count -= 1
                 continue
 
             # It's important these come last, since they're subpatterns of the above
@@ -98,15 +118,13 @@ if __name__ == "__main__":
             match = ok.match(line)
             if match:
                 passed[filename] += 1
+                expected_test_count -= 1
                 continue
 
             match = not_ok.match(line)
             if match:
                 errors[filename] += 1
-                continue
-
-            match = plan.match(line)
-            if match:
+                expected_test_count -= 1
                 continue
 
             match = comment.match(line)

--- a/test/start.t
+++ b/test/start.t
@@ -139,7 +139,7 @@ class TestStart(TestCase):
         self.assertNotIn("Recorded bar foo", out)
 
     def test_single_interval_enclosing_exclusion(self):
-        """Add one interval that encloseѕ an exclusion, and is therefore flattened"""
+        """Add one interval that encloses an exclusion, and is therefore flattened"""
         self.t.configure_exclusions([(time(18, 5, 11), time(9, 11, 50)),
                                      (time(12, 22, 44), time(13, 32, 23))])
 

--- a/test/stop.t
+++ b/test/stop.t
@@ -118,7 +118,7 @@ class TestStop(TestCase):
         self.assertIn("The current interval does not have the 'four' tag.", err)
 
     def test_single_interval_enclosing_exclusion(self):
-        """Add one interval that encloseѕ an exclusion, and is therefore flattened"""
+        """Add one interval that encloses an exclusion, and is therefore flattened"""
         self.t.configure_exclusions([(time(18, 5, 11), time(9, 11, 50)),
                                      (time(12, 22, 44), time(13, 32, 23))])
 

--- a/test/track.t
+++ b/test/track.t
@@ -58,7 +58,7 @@ class TestTrack(TestCase):
         self.assertClosedInterval(j[0], expectedTags=["foo"])
 
     def test_single_interval_enclosing_exclusion(self):
-        """Add one interval that encloseѕ an exclusion, and is therefore flattened"""
+        """Add one interval that encloses an exclusion, and is therefore flattened"""
         self.t.configure_exclusions([(time(18, 0, 0), time(9, 0, 0)),
                                     (time(12, 0, 0), time(13, 0, 0))])
 


### PR DESCRIPTION
I was running into an issue recently where I thought I added a problem to a test, but it was failing on the current dev branch but `make test` was not reporting the errors since it was aborting without writing a "not ok" line.

Ultimately my problem was that I a) did not have python3-dateutil installed and run_all was switched to using python3 and b) My locale was not set to use UTF-8 encoding and there were unicode characters in the docstrings in 3 of the python test files.