### PR TITLE
259: Upgrade on-modify.timewarrior to python3

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ###############################################################################
 #
 # Copyright 2015 - 2016, Paul Beckingham, Federico Hernandez.


### PR DESCRIPTION
Regarding #259.
The hook script seems to be compatible to python3 without further modifications.  