### PR TITLE
Database: Fix error when empty datafile is most recent / oldest

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -47,6 +47,12 @@ Database::iterator::iterator (files_iterator fbegin, files_iterator fend) :
       while ((lines_it == lines_end) && (files_it != files_end))
       {
         ++files_it;
+        if (files_it != files_end)
+        {
+          auto& lines = files_it->allLines ();
+          lines_it = lines.rbegin ();
+          lines_end = lines.rend ();
+        }
       }
     }
 }
@@ -122,6 +128,12 @@ Database::reverse_iterator::reverse_iterator (files_iterator fbegin,
       while ((lines_it == lines_end) && (files_it != files_end))
       {
         ++files_it;
+        if (files_it != files_end)
+        {
+          auto& lines = files_it->allLines ();
+          lines_it = lines.begin ();
+          lines_end = lines.end ();
+        }
       }
     }
 }


### PR DESCRIPTION
NOTE: This change is in #283 as well since it was needed to pass the tests.

This fixes an error I introduced in the recent code to avoid loading the
entire database. It only now appeared because I happened to run the test
suite on the first of the month.

Below is the error I was seeing:

```
  $ test/delete.t
  1..5
  ok 1 - delete.t: Delete a single closed interval
  ok 2 - delete.t: Delete an interval which encloses a month border
  ok 3 - delete.t: Delete a mix of open/closed intervals
  not ok 4 - delete.t: Delete a single open interval
  # FAIL: AssertionError on file test/delete.t line 56 in test_delete_open:
  # 'self.assertEqual(len(j), 1)':
  #       0 != 1
  ok 5 - delete.t: Delete an open interval that spans over an exclusion
```

The problem is that when there was one entry in the 2020-01.data file
and one in the 2020-02.data file, when I deleted the single one in the
2020-02.data file, the interator constructor was not updating the lines
iterator when moving to a new file.