### PR TITLE
285: Pass interval id to extensions

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -99,16 +99,14 @@ std::string Interval::serialize () const
 std::string Interval::json () const
 {
   std::stringstream out;
-  out << '{';
+  out << "{\"id\":" << id;
 
-  if (is_started ())
-    out << "\"start\":\"" << start.toISO () << "\"";
+  if (is_started ()) {
+    out << ",\"start\":\"" << start.toISO () << "\"";
+  }
 
-  if (is_ended ())
-  {
-    if (is_started ())
-      out << ',';
-    out << "\"end\":\"" << end.toISO () << "\"";
+  if (is_ended ()) {
+    out << ",\"end\":\"" << end.toISO () << "\"";
   }
 
   if (! _tags.empty ())


### PR DESCRIPTION
Passes the `id` of an interval to extensions. Now, stdin of an extension looks like this:

```
{"id":99,"start":"20191219T183718Z","end":"20191219T185724Z","annotation":"project:gaming"},
{"id":98,"start":"20191219T211035Z","end":"20191219T220034Z","tags":["project:gaming"]},
{"id":97,"start":"20200107T090000Z","end":"20200107T113235Z","tags":["tempo:ABC-477"]},
{"id":96,"start":"20200107T125607Z","end":"20200107T152439Z","tags":["tempo:ABC-477"]},
{"id":95,"start":"20200107T165000Z","end":"20200107T180803Z","tags":["tempo:ABC-477"]},
{"id":94,"start":"20200108T081022Z","end":"20200108T083142Z","tags":["tempo:ABC-477"]},
```

Resolves #285