### PR TITLE
#290 check serialization before committing to database

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -33,6 +33,25 @@
 #include <JSON.h>
 #include <Interval.h>
 
+////////////////////////////////////////////////////////////////////////////////
+bool Interval::operator== (const Interval& other) const
+{
+  if ((annotation == other.annotation) &&
+      (_tags == other._tags) &&
+      (synthetic == other.synthetic) &&
+      (id == other.id))
+  {
+    return Range::operator== (other);
+  }
+
+  return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+bool Interval::operator!= (const Interval& other) const
+{
+  return ! operator== (other);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 bool Interval::empty () const

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -36,8 +36,10 @@ class Interval : public Range
 public:
   Interval () = default;
   Interval (const Datetime& start, const Datetime& end) : Range (start, end) {}
-  bool empty () const;
+  bool operator== (const Interval&) const;
+  bool operator!= (const Interval&) const;
 
+  bool empty () const;
   bool hasTag (const std::string&) const;
   std::set <std::string> tags () const;
   void tag (const std::string&);

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -27,6 +27,7 @@
 #include <Color.h>
 #include <timew.h>
 #include <iostream>
+#include <sstream>
 
 static bool debugMode = false;
 static std::string debugIndicator = ">>";
@@ -54,7 +55,14 @@ void setDebugColor (const Color& color)
 void debug (const std::string& msg)
 {
   if (debugMode)
-    std::cout << debugColor.colorize (debugIndicator + " " + msg) << "\n";
+  {
+    std::stringstream sstr (msg);
+    std::string line;
+    while (std::getline (sstr, line, '\n'))
+    {
+      std::cout << debugColor.colorize (debugIndicator + " " + line) << "\n";
+    }
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
While this does not fix the underlying problems, I do think it to be a generally advisable change to prevent updates to the database that can not be parsed.

Ensure that the IntervalFactory can parse the string returned by
Interval::serialize before writing to database.

If a user attempts to add a non-parseable date, you will get an error like:

  $ TZ="GMT" timew track 7h before 1970-01-01T00:00:00 test
  Note: 'test' is a new tag.
  Internal error. Failed encode / decode check.

Or if the user attempts to add a tag that is not supported:

  $ timew start 1970-01-01T00:00:00 '\"TEST\"'
  Note: '"\\"TEST\\""' is a new tag.
  Internal error. Failed encode / decode check.

On #159, the serializer / deserializer should be able to handle the escaped
quotes, but it is another example where we do not want any entry written into
the database that cannot be properly parsed. This change will also add more
verbose debugging information if the :debug flag is passed, like:

  $ timew start 1970-01-01T00:00:00 '\"TEST\"' :debug
  CLI Parser
    _original_args
      timew start 1970-01-01T00:00:00 \"TEST\" :debug
    _args
      word basename='timew' raw='timew' BINARY
      word canonical='start' raw='start' ORIGINAL CMD
      date raw='1970-01-01T00:00:00' ORIGINAL FILTER
      word raw='\"TEST\"' ORIGINAL FILTER TAG
      word canonical=':debug' raw=':debug' ORIGINAL HINT FILTER

  >> 2020-02.data: 0 intervals
  >> 1970-01.data: 0 intervals
  >> 1969-12.data: 0 intervals
  >> Loaded 0 tracked intervals
  Note: '"\\"TEST\\""' is a new tag.
  >> Datafile::addInterval() failed.
  >> Encode / decode check failed:
  >>   inc 19700101T060000Z # "\\"TEST\\""
  >> is not equal to:
  >>   inc 19700101T060000Z # "TEST\\\"\"" \
  Internal error. Failed encode / decode check.
  >> Timer timew 0.002137 sec

Closes #290
Related to #159 