### PR TITLE
#293 filtering by tag can produce wrong ids

### DIFF
--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -69,7 +69,7 @@ bool Interval::hasTag (const std::string& tag) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::set <std::string> Interval::tags () const
+const std::set <std::string>& Interval::tags () const
 {
   return _tags;
 }

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -41,7 +41,7 @@ public:
 
   bool empty () const;
   bool hasTag (const std::string&) const;
-  std::set <std::string> tags () const;
+  const std::set <std::string>& tags () const;
   void tag (const std::string&);
   void untag (const std::string&);
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -24,6 +24,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include <deque>
 
 #include <cmake.h>
@@ -587,6 +588,15 @@ std::vector <Range> subtractRanges (
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// An interval matches a filter range if the start/end overlaps
+bool matchesRange (const Interval& interval, const Range& filter)
+{
+  return ((filter.start.toEpoch () == 0 &&
+           filter.end.toEpoch () == 0
+          ) || interval.intersects (filter));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // An interval matches a filter interval if the start/end overlaps, and all
 // filter interval tags are found in the interval.
 //
@@ -625,14 +635,15 @@ std::vector <Range> subtractRanges (
 //
 bool matchesFilter (const Interval& interval, const Interval& filter)
 {
-  if ((filter.start.toEpoch () == 0 &&
-       filter.end.toEpoch () == 0
-     ) || interval.intersects (filter))
+  if (matchesRange (interval, filter))
   {
     for (auto& tag : filter.tags ())
+    {
       if (! interval.hasTag (tag))
+      {
         return false;
-
+      }
+    }
     return true;
   }
 
@@ -696,9 +707,9 @@ std::vector <Interval> getTracked (
     // Since we are moving backwards, and the intervals are in sorted order,
     // if the filter is after the interval, we know there will be no more
     // matches
-    if (matchesFilter (interval, filter))
+    if (matchesRange (interval, filter))
     {
-      intervals.push_front (interval);
+      intervals.push_front (std::move (interval));
     }
     else if (interval.start.toEpoch () >= filter.start.toEpoch ())
     {
@@ -738,14 +749,36 @@ std::vector <Interval> getTracked (
     }
   }
 
-  // Assign an ID to each interval.
+  // Assign an ID to each interval before we prune ones that do not have
+  // matching tags
   for (unsigned int i = 0; i < intervals.size (); ++i)
   {
     intervals[i].id = intervals.size () - i + id_skip;
   }
 
+  // Now prune the intervals without matching tags
+  if (filter.tags ().size () > 0)
+  {
+    auto cmp = [&filter] (const Interval& interval)
+               {
+                 for (const auto& tag : filter.tags ())
+                 {
+                   if (! interval.hasTag (tag))
+                   {
+                     return true;
+                   }
+                 }
+                 return false;
+               };
+
+    intervals.erase (std::remove_if (intervals.begin (), intervals.end (), cmp),
+                     intervals.end ());
+  }
+
   debug (format ("Loaded {1} tracked intervals", intervals.size ()));
-  return subset (filter, intervals);
+
+  return std::vector <Interval> (std::make_move_iterator (intervals.begin ()),
+                                 std::make_move_iterator (intervals.end ()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/timew.h
+++ b/src/timew.h
@@ -50,6 +50,7 @@ std::vector <Range>     merge             (const std::vector <Range>&);
 std::vector <Range>     addRanges         (const Range&, const std::vector <Range>&, const std::vector <Range>&);
 std::vector <Range>     subtractRanges    (const std::vector <Range>&, const std::vector <Range>&);
 Range                   outerRange        (const std::vector <Interval>&);
+bool                    matchesRange      (const Interval&, const Range&);
 bool                    matchesFilter     (const Interval&, const Interval&);
 Interval                clip              (const Interval&, const Range&);
 std::vector <Interval>  getTracked        (Database&, const Rules&, Interval&);

--- a/test/summary.t
+++ b/test/summary.t
@@ -137,6 +137,24 @@ W10 2017-03-09 Thu @4 Tag1 8:43:08 9:38:15 0:55:07 0:55:07
                                                    0:55:07
 """, out)
 
+    def test_non_contiguous_with_tag_filter(self):
+        """Summary should print data filtered by tag when tags are non-contiguous"""
+        self.t("track Tag1 2017-03-09T08:43:08 - 2017-03-09T09:38:15")
+        self.t("track Tag2 2017-03-09T11:38:39 - 2017-03-09T11:45:35")
+        self.t("track Tag1 Tag3 2017-03-09T11:46:21 - 2017-03-09T12:00:17")
+        self.t("track Tag2 Tag4 2017-03-09T12:01:49 - 2017-03-09T12:28:46")
+
+        code, out, err = self.t("summary 2017-03-09 Tag1 :ids")
+
+        self.assertIn("""
+Wk  Date       Day ID Tags          Start      End    Time   Total
+--- ---------- --- -- ---------- -------- -------- ------- -------
+W10 2017-03-09 Thu @4 Tag1        8:43:08  9:38:15 0:55:07
+                   @2 Tag1, Tag3 11:46:21 12:00:17 0:13:56 1:09:03
+
+                                                           1:09:03
+""", out)
+
     def test_with_day_gap(self):
         """Summary should skip days with no data"""
         self.t("track 2017-03-09T10:00:00 - 2017-03-09T11:00:00")


### PR DESCRIPTION
This fixes a bug I introduced in the change where the database is not fully loaded, and adds a test to check for non-contiguous result sets when filtering by tags.

Closes #293 