### PR TITLE
Do not display misleading output on errors

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -307,7 +307,7 @@ void Database::addInterval (const Interval& interval, bool verbose)
   {
     if (_tagInfoDatabase.incrementTag (tag) == -1 && verbose)
     {
-      std::cout << "Note: '" << quoteIfNeeded (tag) << "' is a new tag." << std::endl;
+      timew::cout << "Note: '" << quoteIfNeeded (tag) << "' is a new tag." << std::endl;
     }
   }
 
@@ -517,10 +517,10 @@ void Database::initializeTagDatabase ()
 
   if (!exists)
   {
-    std::cout << "Tags database does not exist. ";
+    timew::cout << "Tags database does not exist. ";
   }
   
-  std::cout << "Recreating from interval data..." << std::endl;
+  timew::cout << "Recreating from interval data..." << std::endl;
 
   for (; it != end; ++it)
   {

--- a/src/Extensions.cpp
+++ b/src/Extensions.cpp
@@ -70,11 +70,13 @@ int Extensions::callExtension (
 {
   if (_debug)
   {
-    std::cout << "Extension: Calling " << script << '\n'
-              << "Extension: input";
+    timew::cout << "Extension: Calling " << script << '\n'
+                << "Extension: input";
 
     for (auto& i : input)
-      std::cout << "  " << i << '\n';
+    {
+      timew::cout << "  " << i << '\n';
+    }
   }
 
   auto inputStr = join ("\n", input);
@@ -107,7 +109,9 @@ int Extensions::callExtension (
   output = split (outputStr, '\n');
 
   if (_debug)
-    std::cout << "Extension: Completed with status " << status << '\n';
+  {
+    timew::cout << "Extension: Completed with status " << status << '\n';
+  }
 
   return status;
 }

--- a/src/commands/CmdAnnotate.cpp
+++ b/src/commands/CmdAnnotate.cpp
@@ -80,11 +80,11 @@ int CmdAnnotate (
     {
       if (annotation.empty ())
       {
-        std::cout << "Removed annotation from @" << modified.id << std::endl;
+        timew::cout << "Removed annotation from @" << modified.id << std::endl;
       }
       else
       {
-        std::cout << "Annotated @" << modified.id << " with \"" << annotation << "\"" << std::endl;
+        timew::cout << "Annotated @" << modified.id << " with \"" << annotation << "\"" << std::endl;
       }
     }
   }

--- a/src/commands/CmdCancel.cpp
+++ b/src/commands/CmdCancel.cpp
@@ -42,7 +42,9 @@ int CmdCancel (
   if (!latest.is_open ())
   {
     if (verbose)
-      std::cout << "There is no active time tracking.\n";
+    {
+      timew::cout << "There is no active time tracking.\n";
+    }
 
     return 0;
   }
@@ -52,7 +54,9 @@ int CmdCancel (
   journal.endTransaction ();
 
   if (verbose)
-    std::cout << "Canceled active time tracking.\n";
+  {
+    timew::cout << "Canceled active time tracking.\n";
+  }
 
   return 0;
 }

--- a/src/commands/CmdChart.cpp
+++ b/src/commands/CmdChart.cpp
@@ -101,21 +101,23 @@ int renderChart (
   {
     if (verbose)
     {
-      std::cout << "No filtered data found";
+      timew::cout << "No filtered data found";
 
       if (filter.is_started ())
       {
-        std::cout << " in the range " << filter.start.toISOLocalExtended ();
+        timew::cout << " in the range " << filter.start.toISOLocalExtended ();
         if (filter.is_ended ())
-          std::cout << " - " << filter.end.toISOLocalExtended ();
+        {
+          timew::cout << " - " << filter.end.toISOLocalExtended ();
+        }
       }
 
       if (! filter.tags ().empty ())
       {
-        std::cout << " tagged with " << joinQuotedIfNeeded (", ", filter.tags ());
+        timew::cout << " tagged with " << joinQuotedIfNeeded (", ", filter.tags ());
       }
 
-      std::cout << ".\n";
+      timew::cout << ".\n";
     }
 
     return 0;
@@ -162,7 +164,7 @@ int renderChart (
 
   Chart chart (configuration);
 
-  std::cout << chart.render (filter, tracked, exclusions, holidays);
+  timew::cout << chart.render (filter, tracked, exclusions, holidays);
 
   return 0;
 }

--- a/src/commands/CmdConfig.cpp
+++ b/src/commands/CmdConfig.cpp
@@ -120,11 +120,11 @@ int CmdConfig (
   {
     if (change)
     {
-      std::cout << "Config file " << rules.file () << " modified.\n";
+      timew::cout << "Config file " << rules.file () << " modified.\n";
     }
     else
     {
-      std::cout << "No changes made.\n";
+      timew::cout << "No changes made.\n";
     }
   }
 

--- a/src/commands/CmdContinue.cpp
+++ b/src/commands/CmdContinue.cpp
@@ -120,7 +120,7 @@ int CmdContinue (
 
   if (verbose)
   {
-    std::cout << intervalSummarize (database, rules, to_copy);
+    timew::cout << intervalSummarize (database, rules, to_copy);
   }
 
   return 0;

--- a/src/commands/CmdDefault.cpp
+++ b/src/commands/CmdDefault.cpp
@@ -41,7 +41,7 @@ int CmdDefault (Rules& rules, Database& database)
   {
     if (verbose)
     {
-      std::cout << intervalSummarize (database, rules, interval);
+      timew::cout << intervalSummarize (database, rules, interval);
     }
 
     return 0;
@@ -49,23 +49,23 @@ int CmdDefault (Rules& rules, Database& database)
 
   if (rules.getBoolean ("temp.shiny"))
   {
-    std::cout << '\n'
-              << "Welcome to Timewarrior.\n"
-              << '\n'
-              << "There is built-in help:\n"
-              << "    timew help\n"
-              << "    timew help <command>\n"
-              << "    (and more)\n"
-              << '\n'
-              << "There is a fully-detailed man page:\n"
-              << "    man timew\n"
-              << '\n';
+    timew::cout << '\n'
+                << "Welcome to Timewarrior.\n"
+                << '\n'
+                << "There is built-in help:\n"
+                << "    timew help\n"
+                << "    timew help <command>\n"
+                << "    (and more)\n"
+                << '\n'
+                << "There is a fully-detailed man page:\n"
+                << "    man timew\n"
+                << '\n';
     return 0;
   }
 
   if (verbose)
   {
-    std::cout << "There is no active time tracking.\n";
+    timew::cout << "There is no active time tracking.\n";
   }
 
   return 1;

--- a/src/commands/CmdDelete.cpp
+++ b/src/commands/CmdDelete.cpp
@@ -57,7 +57,7 @@ int CmdDelete (
 
     if (verbose)
     {
-      std::cout << "Deleted @" << interval.id << '\n';
+      timew::cout << "Deleted @" << interval.id << '\n';
     }
   }
 

--- a/src/commands/CmdDiagnostics.cpp
+++ b/src/commands/CmdDiagnostics.cpp
@@ -65,7 +65,7 @@ int CmdDiagnostics (
   Database& database,
   const Extensions& extensions)
 {
-  std::stringstream out;
+  std::ostream& out = timew::cout;
   out << '\n'
       << PACKAGE_STRING
       << '\n';
@@ -220,7 +220,6 @@ int CmdDiagnostics (
     out << "               (None)\n";
 
   out << '\n';
-  std::cout << out.str ();
 
   return 0;
 }

--- a/src/commands/CmdExport.cpp
+++ b/src/commands/CmdExport.cpp
@@ -35,7 +35,7 @@ int CmdExport (
   Database& database)
 {
   auto filter = cli.getFilter ();
-  std::cout << jsonFromIntervals (getTracked (database, rules, filter));
+  timew::cout << jsonFromIntervals (getTracked (database, rules, filter));
   return 0;
 }
 

--- a/src/commands/CmdExtensions.cpp
+++ b/src/commands/CmdExtensions.cpp
@@ -27,6 +27,7 @@
 #include <commands.h>
 #include <Table.h>
 #include <iostream>
+#include <timew.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enumerate all extensions.
@@ -62,12 +63,12 @@ int CmdExtensions (
   Directory extDir (rules.get ("temp.db"));
   extDir += "extensions";
 
-  std::cout << '\n'
-            << "Extensions located in:\n"
-            << "  " << extDir._data << '\n'
-            << '\n'
-            << t.render ()
-            << '\n';
+  timew::cout << '\n'
+              << "Extensions located in:\n"
+              << "  " << extDir._data << '\n'
+              << '\n'
+              << t.render ()
+              << '\n';
   return 0;
 }
 

--- a/src/commands/CmdFill.cpp
+++ b/src/commands/CmdFill.cpp
@@ -58,13 +58,13 @@ int CmdFill (
       throw format ("ID '@{1}' does not correspond to any tracking.", id);
 
     Interval from = tracked[tracked.size () - id];
-    std::cout << "# from " << from.dump () << "\n";
+    timew::cout << "# from " << from.dump () << "\n";
     Interval to {from};
 
     database.deleteInterval (from);
     autoFill (rules, database, to);
     validate (cli, rules, database, to);
-    std::cout << "# to " << to.dump () << "\n";
+    timew::cout << "# to " << to.dump () << "\n";
     database.addInterval (to, verbose);
 
     // Note: Feedback generated inside autoFill().

--- a/src/commands/CmdGaps.cpp
+++ b/src/commands/CmdGaps.cpp
@@ -114,14 +114,16 @@ int CmdGaps (
 
   if (table.rows () > 2)
   {
-    std::cout << '\n'
-              << table.render ()
-              << '\n';
+    timew::cout << '\n'
+                << table.render ()
+                << '\n';
   }
   else
   {
     if (verbose)
-      std::cout << "No gaps found.\n";
+    {
+      timew::cout << "No gaps found.\n";
+    }
   }
 
   return 0;

--- a/src/commands/CmdGet.cpp
+++ b/src/commands/CmdGet.cpp
@@ -50,7 +50,7 @@ int CmdGet (
     results.push_back (value);
   }
 
-  std::cout << join (" ", results) << '\n';
+  timew::cout << join (" ", results) << '\n';
   return 0;
 }
 

--- a/src/commands/CmdHelp.cpp
+++ b/src/commands/CmdHelp.cpp
@@ -29,83 +29,86 @@
 #include <iostream>
 #include <FS.h>
 #include <shared.h>
+#include <timew.h>
 #include <additional-help.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 int CmdHelpUsage (const Extensions& extensions)
 {
-  std::cout << '\n'
-            << "Usage: timew [--version]\n"
-            << "       timew annotate @<id> [@<id> ...] <annotation>\n"
-            << "       timew cancel\n"
-            << "       timew config [<name> [<value> | '']]\n"
-            << "       timew continue [@<id>] [<date>|<interval>]\n"
-            << "       timew day [<interval>] [<tag> ...]\n"
-            << "       timew delete @<id> [@<id> ...]\n"
-            << "       timew diagnostics\n"
-            << "       timew export [<interval>] [<tag> ...]\n"
-            << "       timew extensions\n"
-            << "       timew gaps [<interval>] [<tag> ...]\n"
-            << "       timew get <DOM> [<DOM> ...]\n"
-            << "       timew help [<command> | " << join ( " | ", timew_help_concepts) << "]\n"
-            << "       timew join @<id> @<id>\n"
-            << "       timew lengthen @<id> [@<id> ...] <duration>\n"
-            << "       timew modify (start|end) @<id> <date>\n"
-            << "       timew month [<interval>] [<tag> ...]\n"
-            << "       timew move @<id> <date>\n"
-            << "       timew [report] <report> [<interval>] [<tag> ...]\n"
-            << "       timew shorten @<id> [@<id> ...] <duration>\n"
-            << "       timew show\n"
-            << "       timew split @<id> [@<id> ...]\n"
-            << "       timew start [<date>] [<tag> ...]\n"
-            << "       timew stop [<tag> ...]\n"
-            << "       timew summary [<interval>] [<tag> ...]\n"
-            << "       timew tag @<id> [@<id> ...] <tag> [<tag> ...]\n"
-            << "       timew tags [<interval>] [<tag> ...]\n"
-            << "       timew track <interval> [<tag> ...]\n"
-            << "       timew undo\n"
-            << "       timew untag @<id> [@<id> ...] <tag> [<tag> ...]\n"
-            << "       timew week [<interval>] [<tag> ...]\n"
-            << '\n';
+  auto& cout = timew::cout;
+
+  cout << '\n'
+       << "Usage: timew [--version]\n"
+       << "       timew annotate @<id> [@<id> ...] <annotation>\n"
+       << "       timew cancel\n"
+       << "       timew config [<name> [<value> | '']]\n"
+       << "       timew continue [@<id>] [<date>|<interval>]\n"
+       << "       timew day [<interval>] [<tag> ...]\n"
+       << "       timew delete @<id> [@<id> ...]\n"
+       << "       timew diagnostics\n"
+       << "       timew export [<interval>] [<tag> ...]\n"
+       << "       timew extensions\n"
+       << "       timew gaps [<interval>] [<tag> ...]\n"
+       << "       timew get <DOM> [<DOM> ...]\n"
+       << "       timew help [<command> | " << join ( " | ", timew_help_concepts) << "]\n"
+       << "       timew join @<id> @<id>\n"
+       << "       timew lengthen @<id> [@<id> ...] <duration>\n"
+       << "       timew modify (start|end) @<id> <date>\n"
+       << "       timew month [<interval>] [<tag> ...]\n"
+       << "       timew move @<id> <date>\n"
+       << "       timew [report] <report> [<interval>] [<tag> ...]\n"
+       << "       timew shorten @<id> [@<id> ...] <duration>\n"
+       << "       timew show\n"
+       << "       timew split @<id> [@<id> ...]\n"
+       << "       timew start [<date>] [<tag> ...]\n"
+       << "       timew stop [<tag> ...]\n"
+       << "       timew summary [<interval>] [<tag> ...]\n"
+       << "       timew tag @<id> [@<id> ...] <tag> [<tag> ...]\n"
+       << "       timew tags [<interval>] [<tag> ...]\n"
+       << "       timew track <interval> [<tag> ...]\n"
+       << "       timew undo\n"
+       << "       timew untag @<id> [@<id> ...] <tag> [<tag> ...]\n"
+       << "       timew week [<interval>] [<tag> ...]\n"
+       << '\n';
 
   if (!extensions.all ().empty ())
   {
-    std::cout << "Extensions (extensions do not provide help):\n";
+    cout << "Extensions (extensions do not provide help):\n";
 
     for (auto& ext : extensions.all ())
     {
-      std::cout << "       " << Path (ext).name () << '\n';
+      cout << "       " << Path (ext).name () << '\n';
     }
 
-    std::cout << '\n';
+    cout << '\n';
   }
 
-  std::cout << "Additional help:\n"
-            << "       timew help <command>\n";
+  cout << "Additional help:\n"
+       << "       timew help <command>\n";
 
   for (auto& concept : timew_help_concepts)
   {
-    std::cout << "       timew help " << concept << '\n';
+    cout << "       timew help " << concept << '\n';
   }
 
-  std::cout << '\n'
-            << "Interval:\n"
-            << "       [from] <date>\n"
-            << "       [from] <date> to/- <date>\n"
-            << "       [from] <date> for <duration>\n"
-            << "       <duration> before/after <date>\n"
-            << "       <duration> ago\n"
-            << "       [for] <duration>\n"
-            << '\n'
-            << "Tag:\n"
-            << "       Word\n"
-            << "       'Single Quoted Words'\n"
-            << "       \"Double Quoted Words\"\n"
-            << "       Escaped\\ Spaces\n"
-            << '\n'
-            << "Configuration overrides:\n"
-            << "       rc.<name>=<value>\n"
-            << '\n';
+  cout << '\n'
+       << "Interval:\n"
+       << "       [from] <date>\n"
+       << "       [from] <date> to/- <date>\n"
+       << "       [from] <date> for <duration>\n"
+       << "       <duration> before/after <date>\n"
+       << "       <duration> ago\n"
+       << "       [for] <duration>\n"
+       << '\n'
+       << "Tag:\n"
+       << "       Word\n"
+       << "       'Single Quoted Words'\n"
+       << "       \"Double Quoted Words\"\n"
+       << "       Escaped\\ Spaces\n"
+       << '\n'
+       << "Configuration overrides:\n"
+       << "       rc.<name>=<value>\n"
+       << '\n';
 
   return 0;
 }

--- a/src/commands/CmdJoin.cpp
+++ b/src/commands/CmdJoin.cpp
@@ -78,7 +78,7 @@ int CmdJoin (
 
   if (verbose)
   {
-    std::cout << "Joined @" << first.id << " and @" << second.id << '\n';
+    timew::cout << "Joined @" << first.id << " and @" << second.id << '\n';
   }
 
   return 0;

--- a/src/commands/CmdLengthen.cpp
+++ b/src/commands/CmdLengthen.cpp
@@ -72,7 +72,7 @@ int CmdLengthen (
 
     if (verbose)
     {
-      std::cout << "Lengthened @" << interval.id << " by " << dur.formatHours () << '\n';
+      timew::cout << "Lengthened @" << interval.id << " by " << dur.formatHours () << '\n';
     }
   }
 

--- a/src/commands/CmdMove.cpp
+++ b/src/commands/CmdMove.cpp
@@ -110,7 +110,7 @@ int CmdMove (
 
   if (verbose)
   {
-    std::cout << "Moved @" << id << " to " << interval.start.toISOLocalExtended () << '\n';
+    timew::cout << "Moved @" << id << " to " << interval.start.toISOLocalExtended () << '\n';
   }
 
   return 0;

--- a/src/commands/CmdReport.cpp
+++ b/src/commands/CmdReport.cpp
@@ -113,7 +113,9 @@ int CmdReport (
 
   // Display the output.
   for (auto& line : output)
-    std::cout << line << '\n';
+  {
+    timew::cout << line << '\n';
+  }
 
   return 0;
 }

--- a/src/commands/CmdResize.cpp
+++ b/src/commands/CmdResize.cpp
@@ -70,7 +70,7 @@ int CmdResize (
 
     if (verbose)
     {
-      std::cout << "Resized @" << interval.id << " to " << dur.formatHours () << '\n';
+      timew::cout << "Resized @" << interval.id << " to " << dur.formatHours () << '\n';
     }
   }
 

--- a/src/commands/CmdShorten.cpp
+++ b/src/commands/CmdShorten.cpp
@@ -78,7 +78,7 @@ int CmdShorten (
 
     if (verbose)
     {
-      std::cout << "Shortened @" << interval.id << " by " << dur.formatHours () << '\n';
+      timew::cout << "Shortened @" << interval.id << " by " << dur.formatHours () << '\n';
     }
   }
 

--- a/src/commands/CmdShow.cpp
+++ b/src/commands/CmdShow.cpp
@@ -51,13 +51,15 @@ int CmdShow (Rules& rules)
       {
         if (previous.size () > 1 &&
             parts.size () == 1)
-          std::cout << '\n';
+        {
+          timew::cout << '\n';
+        }
 
-        std::cout << std::string (2 * (parts.size () - 1), ' ')
-                  << parts[i]
-                  << " = "
-                  << rules.get (name)
-                  << "\n";
+        timew::cout << std::string (2 * (parts.size () - 1), ' ')
+                    << parts[i]
+                    << " = "
+                    << rules.get (name)
+                    << "\n";
       }
       else
       {
@@ -66,14 +68,16 @@ int CmdShow (Rules& rules)
         {
           if (i == 0)
           {
-            std::cout << '\n';
+            timew::cout << '\n';
             if (rules.isRuleType (parts[0]))
-              std::cout << "define ";
+            {
+              timew::cout << "define ";
+            }
           }
 
-          std::cout << std::string (2 * i, ' ')
-                    << parts[i]
-                    << ":\n";
+          timew::cout << std::string (2 * i, ' ')
+                      << parts[i]
+                      << ":\n";
         }
       }
     }

--- a/src/commands/CmdSplit.cpp
+++ b/src/commands/CmdSplit.cpp
@@ -83,7 +83,7 @@ int CmdSplit (
 
     if (verbose)
     {
-      std::cout << "Split @" << interval.id << '\n';
+      timew::cout << "Split @" << interval.id << '\n';
     }
   }
 

--- a/src/commands/CmdStart.cpp
+++ b/src/commands/CmdStart.cpp
@@ -57,7 +57,7 @@ int CmdStart (
 
   if (verbose)
   {
-    std::cout << intervalSummarize (database, rules, interval);
+    timew::cout << intervalSummarize (database, rules, interval);
   }
 
   return 0;

--- a/src/commands/CmdStop.cpp
+++ b/src/commands/CmdStop.cpp
@@ -96,7 +96,9 @@ int CmdStop (
     database.addInterval (interval, verbose);
 
     if (verbose)
-      std::cout << intervalSummarize (database, rules, interval);
+    {
+      timew::cout << intervalSummarize (database, rules, interval);
+    }
   }
 
   // If tags are specified, but are not a full set of tags, remove them
@@ -120,7 +122,9 @@ int CmdStop (
     validate (cli, rules, database, modified);
     database.addInterval (modified, verbose);
     if (verbose)
-      std::cout << '\n' << intervalSummarize (database, rules, modified);
+    {
+      timew::cout << '\n' << intervalSummarize (database, rules, modified);
+    }
   }
 
   journal.endTransaction ();

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -54,21 +54,23 @@ int CmdSummary (
   {
     if (verbose)
     {
-      std::cout << "No filtered data found";
+      timew::cout << "No filtered data found";
 
       if (filter.is_started ())
       {
-        std::cout << " in the range " << filter.start.toISOLocalExtended ();
+        timew::cout << " in the range " << filter.start.toISOLocalExtended ();
         if (filter.is_ended ())
-          std::cout << " - " << filter.end.toISOLocalExtended ();
+        {
+          timew::cout << " - " << filter.end.toISOLocalExtended ();
+        }
       }
 
       if (! filter.tags ().empty ())
       {
-        std::cout << " tagged with " << joinQuotedIfNeeded (", ", filter.tags ());
+        timew::cout << " tagged with " << joinQuotedIfNeeded (", ", filter.tags ());
       }
 
-      std::cout << ".\n";
+      timew::cout << ".\n";
     }
 
     return 0;
@@ -181,10 +183,10 @@ int CmdSummary (
 
   const auto with_holidays = rules.getBoolean ("reports.summary.holidays");
 
-  std::cout << '\n'
-            << table.render ()
-            << (with_holidays ? renderHolidays (createHolidayMap (rules, filter)) : "")
-            << '\n';
+  timew::cout << '\n'
+              << table.render ()
+              << (with_holidays ? renderHolidays (createHolidayMap (rules, filter)) : "")
+              << '\n';
 
   return 0;
 }

--- a/src/commands/CmdTag.cpp
+++ b/src/commands/CmdTag.cpp
@@ -89,7 +89,7 @@ int CmdTag (
 
     if (verbose)
     {
-      std::cout << "Added " << joinQuotedIfNeeded (" ", tags) << " to @" << interval.id << '\n';
+      timew::cout << "Added " << joinQuotedIfNeeded (" ", tags) << " to @" << interval.id << '\n';
     }
   }
 

--- a/src/commands/CmdTags.cpp
+++ b/src/commands/CmdTags.cpp
@@ -68,14 +68,16 @@ int CmdTags (
       t.set (row, 1, rules.has (name) ? rules.get (name) : "-");
     }
 
-    std::cout << '\n'
-              << t.render ()
-              << '\n';
+    timew::cout << '\n'
+                << t.render ()
+                << '\n';
   }
   else
   {
     if (verbose)
-      std::cout << "No data found.\n";
+    {
+      timew::cout << "No data found.\n";
+    }
   }
 
   return 0;

--- a/src/commands/CmdTrack.cpp
+++ b/src/commands/CmdTrack.cpp
@@ -35,7 +35,7 @@ int CmdTrack (
   Database& database,
   Journal& journal)
 {
-  auto boolean = rules.getBoolean ("verbose");
+  auto verbose = rules.getBoolean ("verbose");
 
   auto filter = cli.getFilter ();
 
@@ -52,10 +52,12 @@ int CmdTrack (
 
   for (auto& interval : flatten (filter, getAllExclusions (rules, filter)))
   {
-    database.addInterval (interval, boolean);
+    database.addInterval (interval, verbose);
 
-    if (boolean)
-      std::cout << intervalSummarize (database, rules, interval);
+    if (verbose)
+    {
+      timew::cout << intervalSummarize (database, rules, interval);
+    }
   }
 
   journal.endTransaction ();

--- a/src/commands/CmdUndo.cpp
+++ b/src/commands/CmdUndo.cpp
@@ -73,7 +73,7 @@ int CmdUndo (Rules& rules, Database& database, Journal& journal)
     // No (more) undoing...
     if (verbose)
     {
-      std::cout << "Nothing to undo." << std::endl;
+      timew::cout << "Nothing to undo." << std::endl;
     }
   }
   else
@@ -100,7 +100,7 @@ int CmdUndo (Rules& rules, Database& database, Journal& journal)
 
     if (verbose)
     {
-      std::cout << "Undo" << std::endl;
+      timew::cout << "Undo" << std::endl;
     }
   }
 

--- a/src/commands/CmdUntag.cpp
+++ b/src/commands/CmdUntag.cpp
@@ -88,7 +88,7 @@ int CmdUntag (
 
     if (verbose)
     {
-      std::cout << "Removed " << joinQuotedIfNeeded (" ", tags) << " from @" << interval.id << '\n';
+      timew::cout << "Removed " << joinQuotedIfNeeded (" ", tags) << " from @" << interval.id << '\n';
     }
   }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -38,7 +38,7 @@ bool lightweightVersionCheck (int argc, const char** argv)
 {
   if (argc == 2 && std::string (argv[1]) == "--version")
   {
-    std::cout << VERSION << '\n';
+    timew::cout << VERSION << '\n';
     return true;
   }
 
@@ -258,7 +258,9 @@ int dispatchCommand (
 
   // Debug output.
   if (rules.getBoolean ("debug"))
-    std::cout << cli.dump () << '\n';
+  {
+    timew::cout << cli.dump () << '\n';
+  }
 
   // Dispatch to the right command function.
   std::string command = cli.getCommand ();

--- a/src/timew.cpp
+++ b/src/timew.cpp
@@ -47,7 +47,10 @@ int main (int argc, const char** argv)
   // Lightweight version checking that doesn't require initialization or I/O.
   int status = 0;
   if (lightweightVersionCheck (argc, argv))
+  {
+    std::cout << timew::cout.rdbuf ();
     return status;
+  }
 
   try
   {
@@ -129,6 +132,12 @@ int main (int argc, const char** argv)
     << run_time.total_us () / 1000000.0
     << " sec\n";
   debug (s.str ());
+
+
+  if (status >= 0)
+  {
+    std::cout << timew::cout.rdbuf ();
+  }
 
   return status;
 }

--- a/src/timew.h
+++ b/src/timew.h
@@ -27,6 +27,8 @@
 #ifndef INCLUDED_TIMEW
 #define INCLUDED_TIMEW
 
+#include <sstream>
+
 #include <CLI.h>
 #include <Database.h>
 #include <Rules.h>
@@ -35,6 +37,15 @@
 #include <Exclusion.h>
 #include <Palette.h>
 #include <Color.h>
+
+namespace timew
+{
+
+// This is a buffered cout that will only be displayed if there are not any
+// errors.
+extern std::stringstream cout;
+
+};
 
 // data.cpp
 std::vector <Range>     getHolidays       (const Rules&);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -28,6 +28,13 @@
 #include <timew.h>
 #include <string>
 
+namespace timew
+{
+
+std::stringstream cout;
+
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // Escape all 'c' --> '\c'.
 std::string escape (const std::string& input, int c)

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -55,11 +55,13 @@ void autoFill (
     {
       interval.start = earlier->end;
         if (rules.getBoolean ("verbose"))
-        std::cout << "Backfilled "
-                  << (interval.id ? format ("@{1} ", interval.id) : "")
-                  << "to "
-                  << interval.start.toISOLocalExtended ()
-                  << "\n";
+        {
+          timew::cout << "Backfilled "
+                      << (interval.id ? format ("@{1} ", interval.id) : "")
+                      << "to "
+                      << interval.start.toISOLocalExtended ()
+                      << "\n";
+        }
       break;
     }
   }
@@ -73,11 +75,13 @@ void autoFill (
       {
         interval.end = later.start;
         if (rules.getBoolean ("verbose"))
-          std::cout << "Filled "
-                    << (interval.id ? format ("@{1} ", interval.id) : "")
-                    << "to "
-                    << interval.end.toISOLocalExtended ()
-                    << "\n";
+        {
+          timew::cout << "Filled "
+                      << (interval.id ? format ("@{1} ", interval.id) : "")
+                      << "to "
+                      << interval.end.toISOLocalExtended ()
+                      << "\n";
+        }
         break;
       }
     }


### PR DESCRIPTION
This eliminates possibly misleading messages from the console. For example, in
the following before and after, the after eliminates the message that 'test' was
recorded when it was not due to the user error:

Before this change:

  $ timew stop 15 min ago
  Recorded test
    Started 2020-03-08T13:11:20
    Ended                 40:31
    Total               0:29:11
  The current interval does not have the '15' tag.

After this change:

  $ timew stop 15 min ago
  The current interval does not have the '15' tag.

Closes #280

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>