### PR TITLE
Introduce 'journal.size' configuration item

### DIFF
--- a/src/AtomicFile.h
+++ b/src/AtomicFile.h
@@ -48,7 +48,9 @@ public:
 
   bool open ();
   void close ();
+  void remove ();
   void truncate ();
+  size_t size () const;
   void read (std::string& content);
   void read (std::vector <std::string>& lines);
   void append (const std::string& content);

--- a/src/Datafile.cpp
+++ b/src/Datafile.cpp
@@ -148,23 +148,30 @@ void Datafile::commit ()
   if (_dirty)
   {
     AtomicFile file (_file);
-    if (file.open ())
+    if (_lines.size () > 0)
     {
-      // Sort the intervals by ascending start time.
-      std::sort (_lines.begin (), _lines.end ());
-
-      // Write out all the lines.
-      file.truncate ();
-      for (auto& line : _lines)
+      if (file.open ())
       {
-        file.write_raw (line + '\n');
-      }
+        // Sort the intervals by ascending start time.
+        std::sort (_lines.begin (), _lines.end ());
 
-      _dirty = false;
+        // Write out all the lines.
+        file.truncate ();
+        for (auto& line : _lines)
+        {
+          file.write_raw (line + '\n');
+        }
+
+        _dirty = false;
+      }
+      else
+      {
+        throw format ("Could not write to data file {1}", _file._data);
+      }
     }
     else
     {
-      throw format ("Could not write to data file {1}", _file._data);
+      file.remove ();
     }
   }
 }

--- a/src/Journal.cpp
+++ b/src/Journal.cpp
@@ -68,7 +68,7 @@ void Journal::initialize (const std::string& location, int size)
     AtomicFile undo (_location);
     if (undo.exists () && undo.size () > 0)
     {
-      undo.truncate ();
+      undo.remove ();
     }
   }
 }
@@ -180,15 +180,23 @@ Transaction Journal::popLastTransaction ()
   Transaction last = transactions.back ();
   transactions.pop_back ();
 
-  undo.open ();
-  undo.truncate ();
-
-  for (auto& transaction : transactions)
+  if (transactions.empty ())
   {
-    undo.append (transaction.toString ());
+    undo.close ();
+    undo.remove ();
   }
+  else
+  {
+    undo.open ();
+    undo.truncate ();
 
-  undo.close ();
+    for (auto& transaction : transactions)
+    {
+      undo.append (transaction.toString ());
+    }
+
+    undo.close ();
+  }
 
   return last;
 }

--- a/src/Journal.h
+++ b/src/Journal.h
@@ -40,12 +40,13 @@ public:
   Journal(const Journal&) = delete;
   Journal& operator= (const Journal&) = delete;
 
-  void initialize(const std::string&);
+  void initialize(const std::string&, int);
 
   void startTransaction ();
   void endTransaction ();
   void recordConfigAction(const std::string&, const std::string&);
   void recordIntervalAction(const std::string&, const std::string&);
+  bool enabled () const;
 
   Transaction popLastTransaction();
 
@@ -54,6 +55,7 @@ private:
 
   std::string _location {"~/.timewarrior/data/undo.data"};
   std::shared_ptr <Transaction> _currentTransaction = nullptr;
+  int _size {0};
 };
 
 #endif

--- a/src/Rules.cpp
+++ b/src/Rules.cpp
@@ -99,6 +99,9 @@ Rules::Rules ()
     {"theme.colors.today",       "white"},
     {"theme.colors.holiday",     "gray4"},
     {"theme.colors.label",       "gray4"},
+
+    // Options for the journal / undo file.
+    {"journal.size",             "-1"},
   };
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -221,7 +221,7 @@ void initializeDataJournalAndRules (
     }
   }
 
-  journal.initialize (data._data + "/undo.data");
+  journal.initialize (data._data + "/undo.data", rules.getInteger ("journal.size"));
   // Initialize the database (no data read), but files are enumerated.
   database.initialize (data._data, journal);
 }

--- a/test/AtomicFileTest.cpp
+++ b/test/AtomicFileTest.cpp
@@ -24,6 +24,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <cassert>
 #include <sstream>
 #include <memory>
 #include <string>
@@ -451,18 +452,27 @@ int test (UnitTest& t)
     t.fail (test_name);
     t.diag (std::string ("Expected '" + expected + "' read '" + contents + "'"));
   }
+  AtomicFile::reset ();
 
   {
-    AtomicFile test ("test");
+    tempDir.clear ();
+    Path test("test");
+    AtomicFile file(test);
+    file.truncate ();
+    assert (! test.exists ());
+    AtomicFile::finalize_all ();
+    assert (test.exists ());
+    file.remove ();
+    t.is (test.exists (), true, "File not removed before finalize");
+    AtomicFile::finalize_all ();
+    t.is (test.exists (), false, "File is removed after finalize");
   }
-
-  AtomicFile::reset ();
   return 0;
 }
 
 int main (int, char**)
 {
-  UnitTest t (20);
+  UnitTest t (22);
   try
   {
     int ret = test (t);


### PR DESCRIPTION
On some of my systems, my undo file was getting very large. This change introduces a 'max_undo_entries' configuration item that is set to 0/unlimited by default, but for someone who would like timewarrior to automatically limit it to something, then they can allow timewarrior to do this.

I started looking into this since, with the introduction of AtomicFile, the large undo files were copied as part of any new transaction.  Therefore, limiting the size of the undo file *may* be faster depending on the limit that is set (lower is faster) and the speed of the storage where the database is kept.