### PR TITLE
Fix memory leak in JSON parsing

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -468,7 +468,7 @@ void Database::initializeTagDatabase ()
   {
     try
     {
-      json::object *json = dynamic_cast <json::object *>(json::parse (content));
+      std::unique_ptr <json::object> json (dynamic_cast <json::object *>(json::parse (content)));
 
       if (content.empty () || (json == nullptr))
       {

--- a/src/IntervalFactory.cpp
+++ b/src/IntervalFactory.cpp
@@ -108,7 +108,7 @@ Interval IntervalFactory::fromJson (const std::string& jsonString)
 
   if (!jsonString.empty ())
   {
-    auto* json = (json::object*) json::parse (jsonString);
+    std::unique_ptr <json::object> json (dynamic_cast <json::object *> (json::parse (jsonString)));
 
     json::array* tags = (json::array*) json->_data["tags"];
 


### PR DESCRIPTION
The json::object pointer was allocated in the parse function but never
freed.

The way timwarrior is used currently, this leak does not cause any
problems, but...

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>