### PR TITLE
Write tags.data with one entry per line.

### DIFF
--- a/src/TagInfoDatabase.cpp
+++ b/src/TagInfoDatabase.cpp
@@ -108,7 +108,7 @@ std::string TagInfoDatabase::toJson ()
   std::stringstream json;
   bool first = true;
 
-  json << "{";
+  json << "{\n";
 
   for (auto& pair : _tagInformation)
   {
@@ -116,15 +116,15 @@ std::string TagInfoDatabase::toJson ()
 
     if (tagInfo.hasCount ())
     {
-      json << (first ? "" : ",")
-         << "\"" << escape(pair.first, '"') << "\":"
+      json << (first ? "" : ",\n")
+         << "  \"" << escape(pair.first, '"') << "\":"
          << tagInfo.toJson ();
 
       first = (first ? false : first);
     }
   }
 
-  json << "}";
+  json << "\n}";
 
   return json.str ();
 }


### PR DESCRIPTION
This makes it easier to compare and merge the tags file from different machines.