### PR TITLE
on-modify.timewarrior: Separate hierarchical projects as individual tags

### DIFF
--- a/ext/on-modify.timewarrior
+++ b/ext/on-modify.timewarrior
@@ -55,7 +55,8 @@ def extract_tags_from(json_obj):
     tags = [json_obj['description']]
 
     if 'project' in json_obj:
-        tags.append(json_obj['project'])
+        for project in json_obj['project'].split('.'):
+            tags.append(project)
 
     if 'tags' in json_obj:
         tags.extend(json_obj['tags'])


### PR DESCRIPTION
This will seprate a hierarchical project `job.projectA.sprint4` into
individual 3 tags `[job, projectA, sprint4]`.

This will allow flexibility for view reports in timewarrior.