### PR TITLE
Idempotent start

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -314,8 +314,10 @@ void Database::addInterval (const Interval& interval, bool verbose)
   // Get the index into _files for the appropriate Datafile, which may be
   // created on demand.
   auto df = getDatafile (interval.start.year (), interval.start.month ());
-  _files[df].addInterval (interval);
-  _journal->recordIntervalAction ("", interval.json ());
+  if (_files[df].addInterval (interval))
+  {
+    _journal->recordIntervalAction ("", interval.json ());
+  }
 }
 
 void Database::deleteInterval (const Interval& interval)

--- a/src/Datafile.cpp
+++ b/src/Datafile.cpp
@@ -89,8 +89,11 @@ const std::vector <std::string>& Datafile::allLines ()
 
 ////////////////////////////////////////////////////////////////////////////////
 // Accepted intervals;   day1 <= interval.start < dayN
-void Datafile::addInterval (const Interval& interval)
+// Returns true if the interval was added to the datafile
+bool Datafile::addInterval (const Interval& interval)
 {
+  bool lineAdded = false;
+
   // Note: end date might be zero.
   assert (interval.startsWithin (_range));
 
@@ -111,15 +114,26 @@ void Datafile::addInterval (const Interval& interval)
                      serialization, test.serialize ()));
     }
 
-    _lines.push_back (serialization);
-    debug (format ("{1}: Added {2}", _file.name (), _lines.back ()));
-    _dirty = true;
+    auto it = std::find (_lines.begin (), _lines.end (), serialization);
+    if (it == _lines.end ())
+    {
+      _lines.push_back (serialization);
+      debug (format ("{1}: Added {2}", _file.name (), _lines.back ()));
+      _dirty = true;
+      lineAdded = true;
+    }
+    else
+    {
+      debug (format ("{1}: already contained {2}", _file.name (), serialization));
+    }
   }
   catch (const std::string& error)
   {
     debug (format ("Datafile::addInterval() failed.\n{1}", error));
     throw std::string ("Internal error. Failed encode / decode check.");
   }
+
+  return lineAdded;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/Datafile.h
+++ b/src/Datafile.h
@@ -43,7 +43,7 @@ public:
   std::string lastLine ();
   const std::vector <std::string>& allLines ();
 
-  void addInterval (const Interval&);
+  bool addInterval (const Interval&);
   void deleteInterval (const Interval&);
   void commit ();
 

--- a/src/Interval.cpp
+++ b/src/Interval.cpp
@@ -208,7 +208,7 @@ void Interval::setAnnotation (const std::string& annotation)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-std::string Interval::getAnnotation ()
+const std::string& Interval::getAnnotation () const
 {
   return annotation;
 }

--- a/src/Interval.h
+++ b/src/Interval.h
@@ -49,7 +49,7 @@ public:
   void setRange (const Datetime& start, const Datetime& end);
 
   void setAnnotation(const std::string& annotation);
-  std::string getAnnotation();
+  const std::string& getAnnotation() const;
 
   std::string serialize () const;
   std::string json () const;

--- a/src/Transaction.cpp
+++ b/src/Transaction.cpp
@@ -41,11 +41,16 @@ std::vector<UndoAction> Transaction::getActions () const
 
 std::string Transaction::toString () const
 {
-  std::string output = "txn:\n";
+  std::string output;
 
-  for (auto& action : _actions)
+  if (! _actions.empty ())
   {
-    output += action.toString ();
+    output = "txn:\n";
+
+    for (auto& action : _actions)
+    {
+      output += action.toString ();
+    }
   }
 
   return output;

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -104,11 +104,18 @@ static void autoAdjust (
   Interval latest = getLatestInterval (database);
   if (interval.is_open () && latest.encloses (interval))
   {
-    if (latest.tags () == interval.tags ())
+    if ((latest.tags () == interval.tags ()) &&
+        (interval.getAnnotation ().empty () ||
+              interval.getAnnotation () == latest.getAnnotation ()))
     {
-      // If the new interval tags match those of the currently open interval,
-      // then do nothing - the tags are already being tracked.
-      return;
+        // This is most likely a case where the user is starting tracking with
+        // tags that are currently actively being tracked. We do not want to
+        // make any changes to the database in this case, so make the new
+        // interval match the current latest interval. The Database will see
+        // that it matches an existing interval instead of adding it as a new
+        // one.
+        interval = latest;
+        return;
     }
 
     database.deleteInterval (latest);

--- a/test/start.t
+++ b/test/start.t
@@ -271,6 +271,19 @@ class TestStart(TestCase):
         self.t("start 1h ago proja")
         code, out, err = self.t("start 2h ago proja :adjust")
 
+    def test_start_with_same_tags(self):
+        """Start with same tags does not start new interval."""
+        utc_now = datetime.now().utcnow()
+        one_hour_ago = utc_now - timedelta(hours=1) 
+
+        self.t("start {:%Y-%m-%dT%H:%M:%S}Z proja".format(one_hour_ago))
+        self.t("annotate 'annotation'")
+        self.t("start proja")
+        
+        j = self.t.export()
+
+        self.assertEqual(len(j), 1)
+        self.assertOpenInterval(j[0], expectedStart=one_hour_ago, expectedAnnotation="annotation")
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
Closes #351 by restoring the behavior to 1.3.0.


That being said, I wonder if it would make more sense to produce an error if a user tries to run start multiple times? Currently, if someone runs start multiple times, the undo will not undo the start that silently failed, which seems a little surprising to me.

Maybe a start with the same tags should say "Already tracking xxxxx"  and then the :adjust hint could then mean stop the current interval and start a new one even if we're already tracking the same tags?  

However, since I'm not sure if taskwarrior depends on the previous behavior, I submit this change set which restores it.