### PR TITLE
CmdHelp: Include wait.h for exit() support.

### DIFF
--- a/src/commands/CmdHelp.cpp
+++ b/src/commands/CmdHelp.cpp
@@ -24,6 +24,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #include <commands.h>
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
Fixes the following errors when compiling on FreeBSD 12.1:

  [ 75%] Building CXX object src/commands/CMakeFiles/commands.dir/CmdHelp.cpp.o
  /home/user/timew-1.3.0/src/commands/CmdHelp.cpp:123:13: error: use of undeclared identifier 'WIFEXITED'
  return (WIFEXITED (ret)) ? WEXITSTATUS (ret) : -1;
  ^
  /home/user/timew-1.3.0/src/commands/CmdHelp.cpp:123:32: error: use of undeclared identifier 'WEXITSTATUS'
  return (WIFEXITED (ret)) ? WEXITSTATUS (ret) : -1;
  ^
  2 errors generated.
  *** Error code 1

Thanks @kbcb
Related to issue #258

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>