### PR TITLE
CmdDiagnostics: Show per-file error messages.

### DIFF
--- a/src/commands/CmdDiagnostics.cpp
+++ b/src/commands/CmdDiagnostics.cpp
@@ -37,26 +37,41 @@
 ////////////////////////////////////////////////////////////////////////////////
 std::string describeFile (File& file)
 {
-  std::stringstream out;
-  out << file._data
+  try
+  {
+    std::stringstream out;
+    out << file._data
       << " ("
       << (file.is_link ()
-            ? 'l'
-            : (file.is_directory ()
-                 ? 'd'
-                 : '-'))
+          ? 'l'
+          : (file.is_directory ()
+            ? 'd'
+            : '-'))
       << (file.readable ()
-            ? 'r'
-            : '-')
+          ? 'r'
+          : '-')
       << (file.writable ()
-            ? 'w'
-            : '-')
+          ? 'w'
+          : '-')
       << (file.executable ()
-            ? 'x'
-            : '-')
+          ? 'x'
+          : '-')
       << " " << file.size () << " bytes)";
 
-  return out.str ();
+    return out.str ();
+  }
+  catch (const std::string& error)
+  {
+    return file._data + " (" + error + ')';
+  }
+  catch (const std::exception& error)
+  {
+    return file._data + " (" + error.what () + ')';
+  }
+  catch (...)
+  {
+    return file._data + " (Unknown error)";
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/commands/CmdReport.cpp
+++ b/src/commands/CmdReport.cpp
@@ -109,7 +109,11 @@ int CmdReport (
 
   // Run the extensions.
   std::vector <std::string> output;
-  extensions.callExtension (script, split (input, '\n'), output);
+  int rc = extensions.callExtension (script, split (input, '\n'), output);
+  if (rc != 0 && output.size () == 0)
+  {
+    throw format ("'{1}' returned {2} without producing output.", script, rc);
+  }
 
   // Display the output.
   for (auto& line : output)


### PR DESCRIPTION
I had a broken symbolic link in my extensions directory. When I ran
`timew diag` it would simply print on the screen:

```
stat error 2: No such file or directory
```

After this change, there is more context information about the source of
the error:

```
  timew 1.3.0
         Platform: Linux

  Compiler:
          Version: 7.5.0
             Caps: +stdc +stdc_hosted +LP64 +c8 +i32 +l64 +vp64 +time_t64
       Compliance: C++11

  Build Features
            Built: Aug 14 2020 05:57:06
           Commit: 6fe15d26
            CMake: 3.10.2
       Build type: Debug

  Configuration
    TIMEWARRIORDB: -
              Cfg: /home/sruffell/.timewarrior/timewarrior.cfg (-rw- 0 bytes)
         Database: /home/sruffell/.timewarrior (drwx 4096 bytes)
          $EDITOR: vim
      Color theme: Built-in default
                   00 01 02 03 04 05 06 07 08 09 10 11 12

  Extensions
         Location: /home/sruffell/.timewarrior/extensions (drwx 4096 bytes)
                   /home/sruffell/.timewarrior/extensions/tsheet (stat error 2: No such file or directory)
```

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>