### PR TITLE
Use only the current interval duration when summarizing

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -73,7 +73,7 @@ Color tagColor (const Rules& rules, const std::string& tag)
 ////////////////////////////////////////////////////////////////////////////////
 // Summarize either an active or closed interval, for user feedback.
 std::string intervalSummarize (
-  Database& database,
+  Database&,
   const Rules& rules,
   const Interval& interval)
 {
@@ -81,26 +81,7 @@ std::string intervalSummarize (
 
   if (interval.is_started ())
   {
-    // Walk backwards through the inclusions, and stop as soon as the tags
-    // no longer match interval. This means the 'total' is the sum of all time
-    // in the most recent set of intervals for the same tags. This is the
-    // acceptable definition of "the current task".
-    time_t total_recorded = 0;
-
-    for (auto& line : database)
-    {
-      Interval current = IntervalFactory::fromSerialization (line);
-      if (interval.tags () == current.tags ())
-      {
-        total_recorded += current.total ();
-      }
-      else
-      {
-        break;
-      }
-    }
-
-    Duration total (total_recorded);
+    Duration total (interval.total ());
 
     // Combine and colorize tags.
     std::string tags;


### PR DESCRIPTION
There are several instances where the "total" reported in the interval
summary is confusing because the summarize function would walk backward
and add all intervals with the same set of tags.

Closes #248 and #308

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>