### PR TITLE
CmdSummary: Fix calculation of display start in summary table

### DIFF
--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -121,7 +121,7 @@ int CmdSummary (
     days_end = Datetime ();
   }
 
-  for (Datetime day = days_start; day < days_end; day++)
+  for (Datetime day = days_start.startOfDay (); day < days_end; ++day)
   {
     auto day_range = getFullDay (day);
     time_t daily_total = 0;

--- a/test/summary.t
+++ b/test/summary.t
@@ -215,6 +215,20 @@ W{5} {2:%Y-%m-%d} {2:%a} @1 BAZ  10:00:00 11:00:00 1:00:00 1:00:00
 """.format(yesterday, now, tomorrow,
            yesterday.isocalendar()[1], now.isocalendar()[1], tomorrow.isocalendar()[1]), out)
 
+    def test_with_all_hint_and_first_interval_later_in_day(self):
+        """Summary should handle :all hint with first interval that starts later in day than latest interval"""
+        now = datetime.now()
+        yesterday = now - timedelta(days=1)
+
+        self.t("track {0:%Y-%m-%dT%H:%M:%S} - {1:%Y-%m-%dT%H:%M:%S} FOO".format(yesterday + timedelta(seconds=2),
+                                                                                yesterday + timedelta(seconds=3)))
+        self.t("track {0:%Y-%m-%dT%H:%M:%S} - {1:%Y-%m-%dT%H:%M:%S} BAR".format(now - timedelta(seconds=1), now))
+
+        code, out, err = self.t("summary :ids :all")
+        self.assertIn("@2", out)
+        self.assertIn("@1", out)
+        self.assertRegex(out, r'\s{30}0:00:02')
+
     def test_with_named_date_yesterday(self):
         """Summary should work with 'yesterday'"""
         now = datetime.now()


### PR DESCRIPTION
CmdSummary: Show recent intervals that start later in day than first interval with :all

It was possible for `summary` command, when used with the :all hint, to
skip over any intervals that start later than the first interval in the
database.

You can see below how the BAR interval is not displayed in the summary:
```
$ export ISOFMT="+%Y-%m-%dT%H:%M:%S"
$ timew track $(date -d 'yesterday + 5 min' $ISOFMT) for 1h FOO
Create new database in /home/sruffell/.timewarrior? (yes/no) yes
Note: 'FOO' is a new tag.
Recorded FOO
  Started 2020-08-31T07:48:34
  Ended              08:48:34
  Total               1:00:00
$ timew start BAR
Note: 'BAR' is a new tag.
Tracking BAR
  Started 2020-09-01T07:43:44
  Current                  44
  Total               0:00:00
$ timew summary :all

Wk  Date       Day Tags   Start     End    Time   Total
W36 2020-08-31 Mon FOO  7:48:34 8:48:34 1:00:00 1:00:00

                                                1:00:00
```

Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>