### PR TITLE
test: Thread.isAlive() -> Thread.is_alive()

### DIFF
--- a/test/basetest/utils.py
+++ b/test/basetest/utils.py
@@ -136,7 +136,7 @@ def _retrieve_output(thread, timeout, queue, thread_error):
     """Fetch output from binary subprocess queues"""
     # Try to join the thread on failure abort
     thread.join(timeout)
-    if thread.isAlive():
+    if thread.is_alive():
         # Join should have killed the thread. This is unexpected
         raise TimeoutWaitingFor(thread_error + ". Unexpected error")
 


### PR DESCRIPTION
Python added Thread.is_alive() in 2.6 and removed Thread.isAlive() in
3.9.

This change is needed to run the tests with Python 3.9.

https://bugs.python.org/issue37804
Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>