### PR TITLE
Fix encode/decode failure when modifying open interval inside exclusion

### DIFF
--- a/src/Datafile.cpp
+++ b/src/Datafile.cpp
@@ -108,7 +108,7 @@ void Datafile::addInterval (const Interval& interval)
     if (interval != test)
     {
       throw (format ("Encode / decode check failed:\n  {1}\nis not equal to:\n  {2}",
-                     serialization, test.serialize ()));
+                     interval.dump (), test.dump ()));
     }
 
     _lines.push_back (serialization);

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -175,16 +175,16 @@ std::vector <Interval> getIntervalsByIds (
     auto exclusions = getAllExclusions (rules, {latest.start, Datetime ()});
     if (! exclusions.empty ())
     {
-        // We're converting the latest interval into synthetic intervals so we need to skip it
-        ++it;
+      // We're converting the latest interval into synthetic intervals so we need to skip it
+      ++it;
 
-        for (auto& interval : flatten (latest, exclusions))
-        {
-          ++current_id;
-          interval.synthetic = true;
-          interval.id = current_id;
-          synthetic.push_front (interval);
-        }
+      for (auto& interval : flatten (latest, exclusions))
+      {
+        ++current_id;
+        interval.synthetic = true;
+        interval.id = current_id;
+        synthetic.push_front (interval);
+      }
     }
   }
 

--- a/test/docker/opensuse1500
+++ b/test/docker/opensuse1500
@@ -11,8 +11,8 @@ RUN zypper install -y \
            python3-dateutil \
            ruby
 
-RUN gem install asciidoctor
-RUN update-alternatives --install /usr/bin/asciidoctor asciidoctor /usr/lib64/ruby/gems/2.5.0/gems/asciidoctor-2.0.12/bin/asciidoctor 10
+RUN gem install asciidoctor -v 2.0.15
+RUN update-alternatives --install /usr/bin/asciidoctor asciidoctor /usr/lib64/ruby/gems/2.5.0/gems/asciidoctor-2.0.15/bin/asciidoctor 10
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 ENV TZ=Europe/Berlin
 


### PR DESCRIPTION
The fundamental change is to prevent marking the latest "real" interval as a synthetic interval in this case. 

Closes #422