### PR TITLE
Cleanup for PR 423

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -517,17 +517,16 @@ std::vector <Interval> getTracked (
     Interval interval = IntervalFactory::fromSerialization(*it);
     interval.id = ++current_id;
 
-    // Since we are moving backwards in time, and the intervals are in sorted
-    // order, if the filter is after the interval, we know there will be no
-    // more matches
-    if (interval.start < filter.start)
-    {
-      break;
-    }
-
     if (matchesFilter (interval, filter))
     {
       intervals.push_back (std::move (interval));
+    }
+    else if ((interval.start < filter.start) && ! interval.intersects (filter))
+    {
+      // Since we are moving backwards in time, and the intervals are in sorted
+      // order, if the filter is after the interval, we know there will be no
+      // more matches
+      break;
     }
   }
 

--- a/test/export.t
+++ b/test/export.t
@@ -198,6 +198,21 @@ class TestExport(TestCase):
                                   expectedId=2,
                                   expectedTags=["Tag1", "Tag3"])
 
+    def test_export_with_intersecting_filter(self):
+        """Export with filter that is contained by interval"""
+        self.t("track Tag1 2021-02-01T00:00:00 - 2021-03-01T00:00:00")
+        self.t("track Tag2 2021-03-01T00:00:00 - 2021-04-01T00:00:00")
+
+        # Pass a filter to export that is contained within the above intervals
+        # and check that it picks up the containing interval
+        j = self.t.export("2021-02-02 - 2021-02-03")
+
+        self.assertEqual(len(j), 1)
+
+        self.assertClosedInterval(j[0],
+                                  expectedId=2,
+                                  expectedTags=["Tag1"])
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner

--- a/test/modify.t
+++ b/test/modify.t
@@ -257,10 +257,7 @@ class TestModify(TestCase):
         four_hours_before = now - timedelta(hours=4)
 
         now_utc = now.utcnow().replace(second=0, microsecond=0, minute=0)
-        day_before = now_utc - timedelta(days=1)
-        three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
-        five_hours_before_utc = now_utc - timedelta(hours=5)
 
         self.t.configure_exclusions((four_hours_before.time(), three_hours_before.time()))
 


### PR DESCRIPTION
Sorry about this, I made a mistake in #423 where getTracked wouldn't return some intervals that intersect with the filter. I also addressed your notes about the unused variables in test/modify.t

Hopefully this can make it in 1.4.3 before you tag.