### PR TITLE
Minor AtomicFile cleanup

### DIFF
--- a/src/AtomicFile.cpp
+++ b/src/AtomicFile.cpp
@@ -280,26 +280,18 @@ void AtomicFile::impl::finalize ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-AtomicFile::impl::iterator AtomicFile::impl::find (const Path& path)
-{
-  auto end = impl::atomic_files.end ();
-  auto cmp = [&path](const atomic_files_t::value_type& p)
-             {
-               return p->real_file == path;
-             };
-  auto it = std::find_if(impl::atomic_files.begin (), end, cmp);
-  return (it == end) ? end : it;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 AtomicFile::AtomicFile (const Path& path)
 {
-  auto it = impl::find (path);
+  auto end = impl::atomic_files.end ();
+  auto it = std::find_if (impl::atomic_files.begin (), end,
+                          [&path] (const impl::value_type& p)
+                          {
+                            return p->real_file == path;
+                          });
 
-  if (it == impl::atomic_files.end ())
+  if (it == end)
   {
-    pimpl = std::make_shared <impl> (path._data);
+    pimpl = std::make_shared <impl> (path);
     impl::atomic_files.push_back (pimpl);
   }
   else
@@ -401,18 +393,6 @@ void AtomicFile::write_raw (const std::string& content)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void AtomicFile::append (const std::string& path, const std::string& data)
-{
-  return AtomicFile(path).append (data);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void AtomicFile::write (const std::string& path, const std::string& data)
-{
-  AtomicFile::write (Path (path), data);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 void AtomicFile::write (const Path& path, const std::string& data)
 {
   AtomicFile file (path);
@@ -434,14 +414,7 @@ void AtomicFile::write (const Path& path, const std::vector <std::string>& lines
 ////////////////////////////////////////////////////////////////////////////////
 void AtomicFile::read (const Path& path, std::string& content)
 {
-  AtomicFile file (path);
-  file.read (content);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void AtomicFile::read (const std::string& path, std::string& content)
-{
-  AtomicFile::read (Path (path), content);
+  AtomicFile (path).read (content);
 }
 
 void AtomicFile::read (const Path& path, std::vector <std::string>& lines)

--- a/src/AtomicFile.cpp
+++ b/src/AtomicFile.cpp
@@ -82,10 +82,7 @@ struct AtomicFile::impl
   static atomic_files_t atomic_files;
 };
 
-using atomic_files_t = AtomicFile::impl::atomic_files_t;
-using atomics_iterator = atomic_files_t::iterator;
-
-atomic_files_t AtomicFile::impl::atomic_files {};
+AtomicFile::impl::atomic_files_t AtomicFile::impl::atomic_files {};
 bool AtomicFile::impl::allow_atomics {true};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -283,7 +280,7 @@ void AtomicFile::impl::finalize ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-atomics_iterator AtomicFile::impl::find (const Path& path)
+AtomicFile::impl::iterator AtomicFile::impl::find (const Path& path)
 {
   auto end = impl::atomic_files.end ();
   auto cmp = [&path](const atomic_files_t::value_type& p)
@@ -483,7 +480,7 @@ void AtomicFile::finalize_all ()
   sigprocmask (SIG_SETMASK, &old_mask, nullptr);
 
   // Step 3: Cleanup any references
-  atomic_files_t new_atomic_files;
+  impl::atomic_files_t new_atomic_files;
   for (auto& file : impl::atomic_files)
   {
     // Delete entry if we are holding the last reference

--- a/src/AtomicFile.h
+++ b/src/AtomicFile.h
@@ -70,10 +70,8 @@ public:
   static void finalize_all ();
   static void reset ();
 
-public:
-  struct impl;
-
 private:
+  struct impl;
   std::shared_ptr <impl> pimpl;
 };
 

--- a/src/AtomicFile.h
+++ b/src/AtomicFile.h
@@ -56,14 +56,11 @@ public:
   void append (const std::string& content);
   void write_raw (const std::string& content);
 
-  static void append (const std::string& path, const std::string& data);
   static void append (const Path& path, const std::string& data);
 
-  static void write (const std::string& path, const std::string& data);
   static void write (const Path& path, const std::string& data);
   static void write (const Path& path, const std::vector <std::string>& lines);
 
-  static void read (const std::string& path, std::string& content);
   static void read (const Path& path, std::string& content);
   static void read (const Path& path, std::vector <std::string>& lines);
 


### PR DESCRIPTION
This change just fixes a few minor things in AtomicFile. Primarily to eliminate unnecessary code and make the impl private in the AtomicFile class.