### PR TITLE
Add man documentation for configuring tag colors.

### DIFF
--- a/doc/man1/timew-chart.1.adoc
+++ b/doc/man1/timew-chart.1.adoc
@@ -88,6 +88,10 @@ Default value is 'yes'.
 Determines whether the current weekday is shown at left margin.
 Default value is 'yes'.
 
+**tags.**__<tag>__**.color**::
+Assigns a specific foreground and background color to a tag, instead of the default color palette determined by your current theme.
+Examples of valid colors include 'white', 'gray8', 'black on yellow', and 'rgb345'.
+
 == HINTS
 
 *:blank*::

--- a/doc/man1/timew-tags.1.adoc
+++ b/doc/man1/timew-tags.1.adoc
@@ -14,5 +14,5 @@ When a filter is specified, shows only the tags that were used during that time.
 == CONFIGURATION
 
 **tags.**__<tag>__**.color**::
-Assigns a specific foreground and background color to a tag, instead of the default color palette determined by your current theme. +
+Assigns a specific foreground and background color to a tag.
 Examples of valid colors include 'white', 'gray8', 'black on yellow', and 'rgb345'.

--- a/doc/man1/timew-tags.1.adoc
+++ b/doc/man1/timew-tags.1.adoc
@@ -14,5 +14,5 @@ When a filter is specified, shows only the tags that were used during that time.
 == CONFIGURATION
 
 **tags.**__<tag>__**.color**::
-Assigns a specific foreground and background color to a tag, instead of the default color palette determined by your current theme.
+Assigns a specific foreground and background color to a tag, instead of the default color palette determined by your current theme. +
 Examples of valid colors include 'white', 'gray8', 'black on yellow', and 'rgb345'.

--- a/doc/man1/timew-tags.1.adoc
+++ b/doc/man1/timew-tags.1.adoc
@@ -10,3 +10,9 @@ timew-tags - display a list of tags
 == DESCRIPTION
 Displays all the tags that have been used by default.
 When a filter is specified, shows only the tags that were used during that time.
+
+== CONFIGURATION
+
+**tags.**__<tag>__**.color**::
+Assigns a specific foreground and background color to a tag, instead of the default color palette determined by your current theme.
+Examples of valid colors include 'white', 'gray8', 'black on yellow', and 'rgb345'.


### PR DESCRIPTION
Adds this into `man timew-tags`:

```
CONFIGURATION
       tags.<tag>.color
           Assigns a specific foreground and background color to a tag, instead of the default color palette determined by your current theme.
           Examples of valid colors include 'white', 'gray8', 'black on yellow', and 'rgb345'.
```