### PR TITLE
WIP: Add complex tag filtering

### DIFF
--- a/src/IntervalFilterAllWithTags.cpp
+++ b/src/IntervalFilterAllWithTags.cpp
@@ -32,13 +32,33 @@ IntervalFilterAllWithTags::IntervalFilterAllWithTags (std::set <std::string> tag
 
 bool IntervalFilterAllWithTags::accepts (const Interval& interval)
 {
+  bool isOr = false;
   for (auto& tag : _tags)
   {
-    if (! interval.hasTag (tag))
+    if (tag == "OR")
+    {
+      isOr = true;
+      break;
+    }
+  }
+
+  for (auto& tag : _tags)
+  { 
+    bool isNegative = tag[0] == '-';
+    std::string tagName = isNegative ? tag.substr(1) : tag;
+    bool hasTag = interval.hasTag(tagName);
+    if (isNegative) hasTag = !hasTag;
+
+    if (isOr && hasTag)
+    {
+      return true;
+    }
+
+    if (!isOr && !hasTag)
     {
       return false;
     }
   }
 
-  return true;
+  return isOr ? false : true;
 }

--- a/src/IntervalFilterAllWithTags.h
+++ b/src/IntervalFilterAllWithTags.h
@@ -35,12 +35,13 @@
 class IntervalFilterAllWithTags : public IntervalFilter
 {
 public:
-  explicit IntervalFilterAllWithTags(std::set <std::string>);
+  explicit IntervalFilterAllWithTags(std::set <std::string>, const bool complexFiltering);
 
   bool accepts (const Interval&) final;
 
 private:
   const std::set <std::string> _tags {};
+  const bool _complexFiltering {};
 };
 
 #endif //INCLUDED_INTERVALFILTERTAGSET

--- a/src/commands/CmdChart.cpp
+++ b/src/commands/CmdChart.cpp
@@ -100,7 +100,7 @@ int renderChart (
   // Load the data.
   auto filtering = IntervalFilterAndGroup ({
     new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags())
+    new IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"))
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdContinue.cpp
+++ b/src/commands/CmdContinue.cpp
@@ -77,7 +77,7 @@ int CmdContinue (
   }
   else if (!filter.tags ().empty ())
   {
-    auto filtering = IntervalFilterAllWithTags (filter.tags());
+    auto filtering = IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"));
     auto tracked = getTracked (database, rules, filtering);
 
     if (tracked.empty())

--- a/src/commands/CmdExport.cpp
+++ b/src/commands/CmdExport.cpp
@@ -41,7 +41,7 @@ int CmdExport (
 
   auto filtering = IntervalFilterAndGroup ({
     new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags())
+    new IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"))
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdReport.cpp
+++ b/src/commands/CmdReport.cpp
@@ -96,7 +96,7 @@ int CmdReport (
   auto filter = cli.getFilter ();
   auto filtering = IntervalFilterAndGroup ({
     new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags ())
+    new IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"))
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -53,7 +53,7 @@ int CmdSummary (
   // Load the data.
   auto filtering = IntervalFilterAndGroup ({
     new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags())
+    new IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"))
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdTags.cpp
+++ b/src/commands/CmdTags.cpp
@@ -47,7 +47,7 @@ int CmdTags (
   auto filter = cli.getFilter ();
   auto filtering = IntervalFilterAndGroup ({
     new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags ())
+    new IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"))
   });
 
   // Generate a unique, ordered list of tags.

--- a/src/dom.cpp
+++ b/src/dom.cpp
@@ -112,7 +112,7 @@ bool domGet (
     {
       auto filtering = IntervalFilterAndGroup ({
         new IntervalFilterAllInRange ({ filter.start, filter.end }),
-        new IntervalFilterAllWithTags (filter.tags())
+        new IntervalFilterAllWithTags (filter.tags(), rules.getBoolean("complexFiltering"))
       });
 
       auto tracked = getTracked (database, rules, filtering);


### PR DESCRIPTION
Continuation of #456. This WIP PR aims to add complex tag filtering, allowing for boolean operators to be done on tags. Example:

<img width="903" alt="Screenshot 2021-11-11 at 12 13 56 AM" src="https://user-images.githubusercontent.com/1744967/141150240-dfcb9748-237e-48aa-913f-6b947e608779.png">

TODO:
- [ ] Refactor code such that boolean parser is possible
- [ ] Add boolean parser, based off of taskwarrior complex filtering?
- [x] Add basic OR/- support as a test
- [x] Add feature flag
- [ ] Add documentation
- [ ] Add tests

Would close #209.
Would close #64.
Would close #358.