### PR TITLE
Add colors to summary

### DIFF
--- a/doc/man1/timew-summary.1.adoc
+++ b/doc/man1/timew-summary.1.adoc
@@ -22,6 +22,10 @@ The ':ids' hint adds an 'ID' column to the summary report output for interval mo
 Determines whether relevant holidays are shown beneath the report.
 Default value is 'yes'.
 
+**tags.**__<tag>__**.color**::
+Assigns a specific foreground and background color to a tag.
+Examples of valid colors include 'white', 'gray8', 'black on yellow', and 'rgb345'.
+
 == SEE ALSO
 **timew-day**(1),
 **timew-lengthen**(1),

--- a/src/Chart.cpp
+++ b/src/Chart.cpp
@@ -470,7 +470,7 @@ void Chart::renderInterval (
   if (end_offset > start_offset)
   {
     // Determine color of interval.
-    Color colorTrack = intervalColor (track.tags (), tag_colors);
+    Color colorTrack = chartIntervalColor (track.tags (), tag_colors);
 
     // Properly format the tags within the space.
     std::string label;

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -155,7 +155,7 @@ int CmdSummary (
         table.set (row, 3, format ("@{1}", track.id), colorID);
       }
 
-      table.set (row, (ids ? 4 : 3), tags);
+      table.set (row, (ids ? 4 : 3), tags, intervalColor(track.tags(), tag_colors));
 
       if (show_annotation)
       {

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -75,9 +75,7 @@ int CmdSummary (
   }
 
   // Map tags to colors.
-  auto palette = createPalette (rules);
-  auto tag_colors = createTagColorMap (rules, palette, tracked);
-  Color colorID (rules.getBoolean ("color") ? rules.get ("theme.colors.ids") : "");
+  Color colorID (rules.getBoolean("color") ? rules.get ("theme.colors.ids") : "");
 
   auto ids = findHint (cli, ":ids");
   auto show_annotation = findHint (cli, ":annotations");
@@ -155,7 +153,7 @@ int CmdSummary (
         table.set (row, 3, format ("@{1}", track.id), colorID);
       }
 
-      table.set (row, (ids ? 4 : 3), tags, intervalColor(track.tags(), tag_colors));
+      table.set (row, (ids ? 4 : 3), tags, summaryIntervalColor(rules, track.tags()));
 
       if (show_annotation)
       {

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -75,7 +75,7 @@ int CmdSummary (
   }
 
   // Map tags to colors.
-  Color colorID (rules.getBoolean("color") ? rules.get ("theme.colors.ids") : "");
+  Color colorID (rules.getBoolean ("color") ? rules.get ("theme.colors.ids") : "");
 
   auto ids = findHint (cli, ":ids");
   auto show_annotation = findHint (cli, ":annotations");
@@ -153,7 +153,7 @@ int CmdSummary (
         table.set (row, 3, format ("@{1}", track.id), colorID);
       }
 
-      table.set (row, (ids ? 4 : 3), tags, summaryIntervalColor(rules, track.tags()));
+      table.set (row, (ids ? 4 : 3), tags, summaryIntervalColor (rules, track.tags ()));
 
       if (show_annotation)
       {

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -38,8 +38,24 @@
 #include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
-// Select a color to represent the interval.
-Color intervalColor (
+// Select a color to represent the interval in a summary report.
+Color summaryIntervalColor (
+  const Rules& rules,
+  const std::set <std::string>& tags)
+{
+  Color c;
+
+  for (auto& tag : tags)
+  {
+      c.blend (tagColor (rules, tag));
+  }
+
+  return c;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Select a color to represent the interval on a chart.
+Color chartIntervalColor (
   const std::set <std::string>& tags,
   const std::map <std::string, Color>& tag_colors)
 {

--- a/src/timew.h
+++ b/src/timew.h
@@ -69,7 +69,8 @@ void initializeExtensions (CLI&, const Rules&, Extensions&);
 int dispatchCommand (const CLI&, Database&, Journal&, Rules&, const Extensions&);
 
 // helper.cpp
-Color intervalColor (const std::set <std::string>&, const std::map <std::string, Color>&);
+Color summaryIntervalColor (const Rules&, const std::set <std::string>&);
+Color chartIntervalColor (const std::set <std::string>&, const std::map <std::string, Color>&);
 Color tagColor (const Rules&, const std::string&);
 std::string intervalSummarize (const Rules&, const Interval&);
 bool expandIntervalHint (const std::string&, Range&);


### PR DESCRIPTION
Uses the existing `intervalColor` function. Includes documentation consistent with CmdTags and CmdChart.

![Screenshot 2021-11-11 at 1 40 19 AM](https://user-images.githubusercontent.com/1744967/141164753-6b5160b6-1e2a-4381-8d0c-05b302b719a7.png)

Closes #459.