### PR TITLE
Do not leak IntervalFilters in IntervalFilterAndGroup

### DIFF
--- a/src/IntervalFilter.h
+++ b/src/IntervalFilter.h
@@ -34,6 +34,7 @@ class IntervalFilter
 public:
   virtual bool accepts (const Interval&) = 0;
   virtual void reset ();
+  virtual ~IntervalFilter() = default;
 
   bool is_done () const;
 

--- a/src/IntervalFilterAllInRange.cpp
+++ b/src/IntervalFilterAllInRange.cpp
@@ -26,7 +26,7 @@
 
 #include <IntervalFilterAllInRange.h>
 
-IntervalFilterAllInRange::IntervalFilterAllInRange (const Range& range): _range (range)
+IntervalFilterAllInRange::IntervalFilterAllInRange (Range range): _range (std::move(range))
 {}
 
 bool IntervalFilterAllInRange::accepts (const Interval& interval)

--- a/src/IntervalFilterAllInRange.h
+++ b/src/IntervalFilterAllInRange.h
@@ -33,12 +33,12 @@
 class IntervalFilterAllInRange : public IntervalFilter
 {
 public:
-  explicit IntervalFilterAllInRange (const Range&);
+  explicit IntervalFilterAllInRange (Range);
 
   bool accepts (const Interval&) final;
 
 private:
-  const Range& _range;
+  const Range _range;
 };
 
 #endif //INCLUDED_INTERVALFILTERRANGE

--- a/src/IntervalFilterAndGroup.cpp
+++ b/src/IntervalFilterAndGroup.cpp
@@ -26,7 +26,7 @@
 
 #include <IntervalFilterAndGroup.h>
 
-IntervalFilterAndGroup::IntervalFilterAndGroup (const std::vector <IntervalFilter *>& filters) : _filters (filters)
+IntervalFilterAndGroup::IntervalFilterAndGroup (std::vector <std::shared_ptr<IntervalFilter>> filters) : _filters (std::move(filters))
 {}
 
 bool IntervalFilterAndGroup::accepts (const Interval &interval)
@@ -36,7 +36,7 @@ bool IntervalFilterAndGroup::accepts (const Interval &interval)
     return false;
   }
 
-  for (auto filter: _filters)
+  for (auto& filter: _filters)
   {
     if (filter->accepts (interval))
     {
@@ -56,7 +56,7 @@ bool IntervalFilterAndGroup::accepts (const Interval &interval)
 
 void IntervalFilterAndGroup::reset ()
 {
-  for (auto filter: _filters)
+  for (auto& filter: _filters)
   {
     filter->reset ();
   }

--- a/src/IntervalFilterAndGroup.h
+++ b/src/IntervalFilterAndGroup.h
@@ -27,18 +27,19 @@
 #ifndef INCLUDED_INTERVALFILTERANDGROUP
 #define INCLUDED_INTERVALFILTERANDGROUP
 
+#include <memory>
 #include <IntervalFilter.h>
 
 class IntervalFilterAndGroup : public IntervalFilter
 {
 public:
-  explicit IntervalFilterAndGroup (const std::vector <IntervalFilter *>& filters);
+  explicit IntervalFilterAndGroup (std::vector <std::shared_ptr<IntervalFilter>> filters);
 
   bool accepts (const Interval&) final;
   void reset () override;
 
 private:
-  const std::vector<IntervalFilter*> _filters = {};
+  const std::vector<std::shared_ptr<IntervalFilter>> _filters = {};
 };
 
 #endif //INCLUDED_INTERVALFILTERANDGROUP

--- a/src/commands/CmdChart.cpp
+++ b/src/commands/CmdChart.cpp
@@ -98,9 +98,9 @@ int renderChart (
   const bool verbose = rules.getBoolean ("verbose");
 
   // Load the data.
-  auto filtering = IntervalFilterAndGroup ({
-    new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags())
+  IntervalFilterAndGroup filtering ({
+    std::make_shared <IntervalFilterAllInRange> ( Range { filter.start, filter.end }),
+    std::make_shared <IntervalFilterAllWithTags> (filter.tags())
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdExport.cpp
+++ b/src/commands/CmdExport.cpp
@@ -39,9 +39,9 @@ int CmdExport (
 {
   auto filter = cli.getFilter ();
 
-  auto filtering = IntervalFilterAndGroup ({
-    new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags())
+  IntervalFilterAndGroup filtering ({
+    std::make_shared <IntervalFilterAllInRange> ( Range { filter.start, filter.end }),
+    std::make_shared <IntervalFilterAllWithTags> (filter.tags())
   });
 
   auto intervals = getTracked (database, rules, filtering);

--- a/src/commands/CmdReport.cpp
+++ b/src/commands/CmdReport.cpp
@@ -94,9 +94,9 @@ int CmdReport (
 
   // Compose Header info.
   auto filter = cli.getFilter ();
-  auto filtering = IntervalFilterAndGroup ({
-    new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags ())
+  IntervalFilterAndGroup filtering ({
+    std::make_shared <IntervalFilterAllInRange> ( Range { filter.start, filter.end }),
+    std::make_shared <IntervalFilterAllWithTags> (filter.tags ())
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -51,9 +51,9 @@ int CmdSummary (
   auto filter = cli.getFilter (Range { Datetime ("today"), Datetime ("tomorrow") });
 
   // Load the data.
-  auto filtering = IntervalFilterAndGroup ({
-    new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags())
+  IntervalFilterAndGroup filtering ({
+    std::make_shared <IntervalFilterAllInRange> ( Range { filter.start, filter.end }),
+    std::make_shared <IntervalFilterAllWithTags> (filter.tags())
   });
 
   auto tracked = getTracked (database, rules, filtering);

--- a/src/commands/CmdTags.cpp
+++ b/src/commands/CmdTags.cpp
@@ -45,9 +45,9 @@ int CmdTags (
 
   // Create a filter, with no default range.
   auto filter = cli.getFilter ();
-  auto filtering = IntervalFilterAndGroup ({
-    new IntervalFilterAllInRange ({ filter.start, filter.end }),
-    new IntervalFilterAllWithTags (filter.tags ())
+  IntervalFilterAndGroup filtering ({
+    std::make_shared <IntervalFilterAllInRange> ( Range { filter.start, filter.end }),
+    std::make_shared <IntervalFilterAllWithTags> (filter.tags ())
   });
 
   // Generate a unique, ordered list of tags.

--- a/src/dom.cpp
+++ b/src/dom.cpp
@@ -119,9 +119,9 @@ bool domGet (
     // dom.tracked.<...>
     else if (pig.skipLiteral ("tracked."))
     {
-      auto filtering = IntervalFilterAndGroup ({
-        new IntervalFilterAllInRange ({ filter.start, filter.end }),
-        new IntervalFilterAllWithTags (filter.tags())
+      IntervalFilterAndGroup filtering ({
+        std::make_shared <IntervalFilterAllInRange> ( Range { filter.start, filter.end }),
+        std::make_shared <IntervalFilterAllWithTags> (filter.tags())
       });
 
       auto tracked = getTracked (database, rules, filtering);


### PR DESCRIPTION
This eliminates the use of the naked "new" so that when the filters object is
destroyed, the filters are also freed.

This also eliminates a potential issue with binding an r-value reference to a
Range as a reference in IntervalFilterAllInRange. 