### PR TITLE
Add support for XDG Base Directory specification on Unixes

### DIFF
--- a/doc/man1/timew-config.1.adoc
+++ b/doc/man1/timew-config.1.adoc
@@ -8,7 +8,7 @@ timew-config - get and set Timewarrior configuration
 *timew config* [_<name>_ {_<value>_|*''*}]
 
 == DESCRIPTION
-Allows setting and removing configuration values, as an alternative to directly editing your ~/.timewarrior/timewarrior.cfg file.
+Allows setting and removing configuration values, as an alternative to directly editing your _timewarrior.cfg_ file.
 
 == EXAMPLES
 For example:

--- a/doc/man1/timew.1.adoc
+++ b/doc/man1/timew.1.adoc
@@ -132,11 +132,19 @@ Note that the online documentation can be more detailed and more current than th
 
 == FILES
 
+=== Non-Unix systems
 ~/.timewarrior/timewarrior.cfg::
     User configuration file.
 
 ~/.timewarrior/data/YYYY-MM.data::
     Time tracking data files.
+
+=== Unix systems
+${XDG_CONFIG_HOME:-$HOME/.config}/timewarrior/timewarrior.cfg::
+    User configuration file if legacy _~/.timewarrior_ directory doesn't exist.
+
+${XDG_DATA_HOME:-$HOME/.local/share}/timewarrior/data/YYYY-MM.data::
+    Time tracking data files if legacy _~/.timewarrior_ directory doesn't exist.
 
 == pass:[CREDITS & COPYRIGHT]
 Copyright (C) 2015 - 2018 T. Lauf, P. Beckingham, F. Hernandez. +

--- a/doc/man7/timew-config.7.adoc
+++ b/doc/man7/timew-config.7.adoc
@@ -7,7 +7,29 @@ timew-config - Timewarrior configuration file and override options
 **timew rc.**__<name>__**=**__<value>__ _<command>_
 
 == DESCRIPTION
-Timewarrior stores its configuration in the user's home directory in _~/.timewarrior/timewarrior.cfg_.
+Timewarrior stores its configuration in the user's home directory in _~/.timewarrior/timewarrior.cfg_ on non-Unix systems (e.g. Windows or MacOS).
+On Unix systems, XDG Base Directory specification is supported, if _~/.timewarrior_ directory doesn't exist
+(old config directory is still supported and has precedence over XDG BD compliant locations).
+This means configuration is stored in
+_$XDG_CONFIG_HOME/timewarrior/timewarrior.cfg_, which defaults to
+_~/.config/timewarrior/timewarrior.cfg_ if _$XDG_CONFIG_HOME_ environment
+variable is not specified.
+
+Those wanting to migrate their data to a new directory scheme, might do that with following shell snippet:
+
+[source,shell]
+----
+LEGACY="${HOME}/.timewarrior"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/timewarrior"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/timewarrior"
+mkdir -p "${CONFIG_DIR}"
+mkdir -p "${DATA_DIR}"
+mv "${LEGACY}/timewarrior.cfg" "${CONFIG_DIR}"
+mv "${LEGACY}/extensions" "${CONFIG_DIR}"
+mv "${LEGACY}/data" "${DATA_DIR}"
+rmdir "${LEGACY}"
+----
+
 This file contains a mix of rules and configuration settings.
 Note that the TIMEWARRIORDB environment variable can be set to override this location.
 

--- a/doc/rules.txt
+++ b/doc/rules.txt
@@ -1,11 +1,16 @@
 Rules System
 ============
-The Timewarrior rule system reads your ~/.timewarrior/timewarrior.cfg file and
+The Timewarrior rule system reads your timewarrior.cfg file and
 uses the combination of configuration settings and logic within to:
 
 - Define configuration and customization details
 - Define tags, exclusions, constraints
 - Define various policies
+
+On non-Unix systems config file is expected in ~/.timewarrior directory.
+On Unix systems, if legacy ~/.timewarrior directory doesn't exists, config is
+read from $XDG_CONFIG_HOME/timewarrior directory (if not specified,
+$XDG_CONFIG_HOME defaults to ~/.config).
 
 The rules are a mechanism to apply late-bound logic and data to various
 functions. Whenever data changes, the rule system is run, which will run each
@@ -19,8 +24,8 @@ will initially be minimal, but grow to be come more capable.
 
 Format
 ------
-The rules are written as UTF8 text in the ~/.timewarrior/timewarrior.cfg text
-file. Other rules files may be included:
+The rules are written as UTF8 text in the timewarrior.cfg text file. Other
+rules files may be included:
 
   import /path/to/other/rule/file
 

--- a/doc/themes/README
+++ b/doc/themes/README
@@ -4,7 +4,8 @@ The theme files define colors that Timewarrior uses in various situations.
 There are several themes provided with Timewarrior, and you use a theme by importing it into your configuration file.
 Edit this file:
 
-    ~/.timewarrior/timewarrior.cfg
+    ~/.timewarrior/timewarrior.cfg (non-Unix systems or instalations using pre-XDG paths on Unix systems)
+    ${XDG_CONFIG_HOME:-$HOME/.config}/timewarrior/timewarrior.cfg (Unix systems)
 
 And add the import line, which looks like this:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set (timew_SRCS AtomicFile.cpp AtomicFile.h
                 dom.cpp
                 init.cpp
                 helper.cpp
+                paths.cpp      paths.h
                 log.cpp
                 util.cpp
                 validate.cpp)

--- a/src/Database.h
+++ b/src/Database.h
@@ -120,7 +120,7 @@ private:
   void initializeTagDatabase ();
 
 private:
-  std::string               _location {"~/.timewarrior/data"};
+  std::string               _location {};
   std::vector <Datafile>    _files    {};
   TagInfoDatabase           _tagInfoDatabase {};
   Journal*                  _journal {};

--- a/src/commands/CmdDiagnostics.cpp
+++ b/src/commands/CmdDiagnostics.cpp
@@ -29,6 +29,7 @@
 #include <timew.h>
 #include <iostream>
 #include <shared.h>
+#include <paths.h>
 
 #ifdef HAVE_COMMIT
 #include <commit.h>
@@ -163,15 +164,15 @@ int CmdDiagnostics (
       << (env ? env : "-")
       << '\n';
 
-  File cfg (rules.get ("temp.db") + "/timewarrior.cfg");
+  File cfg (paths::configFile ());
   out << "            Cfg: " << describeFile (cfg) << '\n';
 
-  Directory db (rules.get ("temp.db"));
+  Directory db (paths::dbDir ());
   out << "       Database: " << describeFile (db) << '\n';
 
   for (auto& file : database.files ())
   {
-    File df (rules.get ("temp.db") + "/data");
+    File df (paths::dbDataDir ());
     df += file;
     out << "                 " << describeFile (df) << '\n';
   }
@@ -205,8 +206,7 @@ int CmdDiagnostics (
   out << '\n';
 
   // Display extensions.
-  Directory extDir (rules.get ("temp.db"));
-  extDir += "extensions";
+  Directory extDir (paths::extensionsDir ());
 
   out << "Extensions\n"
       << "       Location: " << describeFile (extDir) << '\n';

--- a/src/commands/CmdExtensions.cpp
+++ b/src/commands/CmdExtensions.cpp
@@ -27,12 +27,11 @@
 #include <commands.h>
 #include <Table.h>
 #include <iostream>
+#include "paths.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enumerate all extensions.
-int CmdExtensions (
-  Rules& rules,
-  const Extensions& extensions)
+int CmdExtensions (const Extensions& extensions)
 {
   Table t;
   t.width (1024);
@@ -59,8 +58,7 @@ int CmdExtensions (
     t.set (row, 1, perms);
   }
 
-  Directory extDir (rules.get ("temp.db"));
-  extDir += "extensions";
+  Directory extDir (paths::extensionsDir ());
 
   std::cout << '\n'
             << "Extensions located in:\n"

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -41,7 +41,7 @@ int CmdDefault       (            Rules&, Database&                             
 int CmdDelete        (const CLI&, Rules&, Database&, Journal&                   );
 int CmdDiagnostics   (            Rules&, Database&,           const Extensions&);
 int CmdExport        (const CLI&, Rules&, Database&                             );
-int CmdExtensions    (            Rules&,                      const Extensions&);
+int CmdExtensions    (                                         const Extensions&);
 int CmdFill          (const CLI&, Rules&, Database&, Journal&                   );
 int CmdGaps          (const CLI&, Rules&, Database&                             );
 int CmdGet           (const CLI&, Rules&, Database&                             );

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <unistd.h>
 #include <iostream>
+#include "paths.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 bool lightweightVersionCheck (int argc, const char** argv)
@@ -151,69 +152,7 @@ void initializeDataJournalAndRules (
   }
 
   enableDebugMode (rules.getBoolean ("debug"));
-
-  // The $TIMEWARRIORDB environment variable overrides the default value of ~/.timewarrior
-  Directory dbLocation;
-  char* override = getenv ("TIMEWARRIORDB");
-  dbLocation = Directory (override ? override : "~/.timewarrior");
-
-  // If dbLocation exists, but is not readable/writable/executable, error.
-  if (dbLocation.exists () &&
-      (! dbLocation.readable () ||
-       ! dbLocation.writable () ||
-       ! dbLocation.executable ()))
-  {
-    throw format ("Database is not readable at '{1}'", dbLocation._data);
-  }
-
-  // If dbLocation does not exist, ask whether it should be created.
-  bool shinyNewDatabase = false;
-
-  if (! dbLocation.exists () &&
-      (cli.getHint ("yes", false) ||
-       confirm ("Create new database in " + dbLocation._data + "?")))
-  {
-    dbLocation.create (0700);
-    shinyNewDatabase = true;
-  }
-
-  // Create extensions subdirectory if necessary.
-  Directory extensions (dbLocation);
-  extensions += "extensions";
-
-  if (! extensions.exists ())
-  {
-    extensions.create (0700);
-  }
-
-  // Create data subdirectory if necessary.
-  Directory data (dbLocation);
-  data += "data";
-
-  if (! data.exists ())
-  {
-    data.create (0700);
-  }
-
-  // Load the configuration data.
-  Path configFile (dbLocation);
-  configFile += "timewarrior.cfg";
-
-  if (! configFile.exists ())
-  {
-    File (configFile).create (0600);
-  }
-
-  rules.load (configFile._data);
-
-  // This value is not written out to disk, as there would be no point.
-  // Having located the config file, the 'db' location is already known.
-  // This is just for subsequent internal use.
-  rules.set ("temp.db", dbLocation._data);
-
-  // Perhaps some subsequent code would like to know this is a new db and possibly a first run.
-  if (shinyNewDatabase)
-    rules.set ("temp.shiny", 1);
+  paths::initializeDirs (cli, rules);
 
   if (rules.has ("debug.indicator"))
     setDebugIndicator (rules.get ("debug.indicator"));
@@ -231,9 +170,10 @@ void initializeDataJournalAndRules (
     }
   }
 
-  journal.initialize (data._data + "/undo.data", rules.getInteger ("journal.size"));
+  std::string dbDir = paths::dbDir ();
+  journal.initialize (dbDir + "/undo.data", rules.getInteger ("journal.size"));
   // Initialize the database (no data read), but files are enumerated.
-  database.initialize (data._data, journal);
+  database.initialize (dbDir, journal);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -242,8 +182,7 @@ void initializeExtensions (
   const Rules& rules,
   Extensions& extensions)
 {
-  Directory extDir (rules.get ("temp.db"));
-  extDir += "extensions";
+  Directory extDir (paths::extensionsDir ());
 
   extensions.initialize (extDir._data);
 
@@ -284,7 +223,7 @@ int dispatchCommand (
     else if (command == "delete")      status = CmdDelete        (cli, rules, database, journal            );
     else if (command == "diagnostics") status = CmdDiagnostics   (     rules, database,          extensions);
     else if (command == "export")      status = CmdExport        (cli, rules, database                     );
-    else if (command == "extensions")  status = CmdExtensions    (     rules,                    extensions);
+    else if (command == "extensions")  status = CmdExtensions    (                               extensions);
 /*
     else if (command == "fill")        status = CmdFill          (cli, rules, database, journal            );
 //*/

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -1,0 +1,166 @@
+#include "paths.h"
+#include <FS.h>
+#include <format.h>
+#include <shared.h>
+
+namespace paths
+{
+static const char *legacy_config_dir = "~/.timewarrior";
+static const bool uses_legacy_config = Directory (legacy_config_dir).exists ();
+const char *timewarriordb = getenv ("TIMEWARRIORDB");
+
+#ifdef __unix__
+std::string getPath (const char *xdg_path)
+{
+  if (timewarriordb != nullptr)
+  {
+    return timewarriordb;
+  }
+  else if (uses_legacy_config)
+  {
+    return legacy_config_dir;
+  }
+  else
+  {
+    return std::string (xdg_path) + "/timewarrior";
+  }
+}
+
+const char *getenv_default (const char *env, const char *default_value)
+{
+  const char *value = getenv (env);
+  if (value == nullptr)
+  {
+    return default_value;
+  }
+
+  return value;
+}
+
+static std::string conf_dir = getPath (getenv_default ("XDG_CONFIG_HOME", "~/.config"));
+static std::string data_dir = getPath (getenv_default ("XDG_DATA_HOME", "~/.local/share"));
+std::string configDir () { return conf_dir; }
+std::string dbDir () { return data_dir; }
+
+#else
+std::string getPath ()
+{
+  if (timewarriordb != nullptr)
+  {
+    return timewarriordb;
+  }
+  else
+  {
+    return legacy_config_dir;
+  }
+}
+
+static std::string path = getPath ();
+
+std::string configDir ()
+{
+    return path;
+}
+
+std::string dbDir ()
+{
+    return path;
+}
+
+#endif
+
+std::string configFile () { return configDir () + "/timewarrior.cfg"; }
+std::string dbDataDir () { return dbDir () + "/data"; }
+std::string extensionsDir () { return configDir () + "/extensions"; }
+
+void initializeDirs (const CLI &cli, Rules &rules)
+{
+  Directory configLocation = Directory (configDir ());
+  bool configDirExists = configLocation.exists ();
+
+  if (configDirExists &&
+      (!configLocation.readable () ||
+       !configLocation.writable () ||
+       !configLocation.executable ()))
+  {
+    throw format ("Config is not readable at '{1}'", configLocation._data);
+  }
+
+  Directory dbLocation = Directory (dbDir ());
+  bool dataLocationExists = dbLocation.exists ();
+  if (dataLocationExists &&
+          (!dbLocation.readable () ||
+           !dbLocation.writable () ||
+           !dbLocation.executable ()))
+  {
+    throw format ("Database is not readable at '{1}'", dbLocation._data);
+  }
+
+  std::string question = "";
+  if (!configDirExists)
+  {
+    question += "Create new config in " + configLocation._data + "?";
+  }
+  if (!dataLocationExists && configLocation._data != dbLocation._data)
+  {
+    if (question != "") {
+        question += "\n";
+    }
+    question += "Create new database in " + dbLocation._data + "?";
+  }
+
+  if (!configDirExists || !dataLocationExists)
+  {
+    if (cli.getHint ("yes", false) || confirm (question))
+    {
+      if (!configDirExists)
+      {
+        configLocation.create (0700);
+      }
+      if (!dataLocationExists)
+      {
+        dbLocation.create (0700);
+      }
+    }
+  }
+  // Create extensions subdirectory if necessary.
+  Directory extensionsLocation (extensionsDir ());
+
+  if (!extensionsLocation.exists ())
+  {
+    extensionsLocation.create (0700);
+  }
+
+  // Create data subdirectory if necessary.
+  Directory dbDataLocation (dbDataDir ());
+
+  if (!dbDataLocation.exists ())
+  {
+    dbDataLocation.create (0700);
+  }
+
+  Path configFileLocation (configFile ());
+
+  if (!configFileLocation.exists ())
+  {
+    File (configFileLocation).create (0600);
+  }
+  else
+  {
+    // Load the configuration data.
+    rules.load (configFileLocation);
+  }
+
+  // This value is not written out to disk, as there would be no point.
+  // Having located the config file, the 'db' location is already known.
+  // This is just for subsequent internal use.
+  rules.set ("temp.db", dbLocation);
+  rules.set ("temp.extensions", extensionsLocation);
+  rules.set ("temp.config", configFileLocation);
+
+  // Perhaps some subsequent code would like to know this is a new db and possibly a first run.
+  if (!dataLocationExists)
+    rules.set ("temp.shiny", 1);
+}
+
+} // namespace paths

--- a/src/paths.h
+++ b/src/paths.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2018 - 2021, Thomas Lauf, Paul Beckingham, Federico Hernandez.
+// Copyright 2016 - 2021, Thomas Lauf, Paul Beckingham, Federico Hernandez.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,38 +24,19 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef INCLUDED_JOURNAL
-#define INCLUDED_JOURNAL
-
-
-#include <vector>
+#ifndef INCLUDED_PATH_RESOLVER
+#define INCLUDED_PATH_RESOLVER
 #include <string>
-#include <memory>
-#include <Transaction.h>
+#include <Rules.h>
+#include <CLI.h>
+#include <Rules.h>
 
-class Journal
-{
-public:
-  Journal() = default;
-  Journal(const Journal&) = delete;
-  Journal& operator= (const Journal&) = delete;
-
-  void initialize(const std::string&, int);
-
-  void startTransaction ();
-  void endTransaction ();
-  void recordConfigAction(const std::string&, const std::string&);
-  void recordIntervalAction(const std::string&, const std::string&);
-  bool enabled () const;
-
-  Transaction popLastTransaction();
-
-private:
-  void recordUndoAction (const std::string &, const std::string &, const std::string &);
-
-  std::string _location {};
-  std::shared_ptr <Transaction> _currentTransaction = nullptr;
-  int _size {0};
-};
-
+namespace paths {
+    void initializeDirs (const CLI&, Rules&);
+    std::string configDir ();
+    std::string configFile ();
+    std::string dbDir ();
+    std::string dbDataDir ();
+    std::string extensionsDir ();
+}
 #endif


### PR DESCRIPTION
This adds support for XDG Base Specification on Unix systems (MacOS not included). This fixes https://github.com/GothenburgBitFactory/timewarrior/issues/207.

I'll update documentation when final shape of changes will be agreed upon. For now:
- if $TIMEWARRIORDB exists, store all data there
- if ~/.timewarrior directory exists, and $TIMEWARRIORDB is not defined, store all data there  
- otherwise, store config and extensions in $XDG_CONFIG_HOME/timewarrior; and data in $XDG_DATA_HOME/timewarrior

There is no automatic migration, and I think there shouldn't be. This allows people who dislike XDG BD, to use single directory layout (in fact, they could achieve the same with setting XDG_CONFIG_HOME and XDG_DATA_HOME appropriately, but that would require setting shell alias).