### PR TITLE
Stop looking for key in config when found

### DIFF
--- a/src/Rules.cpp
+++ b/src/Rules.cpp
@@ -36,6 +36,7 @@
 #include <inttypes.h>
 #include <AtomicFile.h>
 #include <JSON.h>
+#include <iostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 Rules::Rules ()
@@ -558,6 +559,7 @@ bool Rules::setConfigVariable (
           change = true;
         }
       }
+      if (found) break;
     }
 
     // If it was not found, then retry in hierarchical form∴

--- a/src/Rules.cpp
+++ b/src/Rules.cpp
@@ -36,7 +36,6 @@
 #include <inttypes.h>
 #include <AtomicFile.h>
 #include <JSON.h>
-#include <iostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 Rules::Rules ()


### PR DESCRIPTION
This PR addresses the issue that multiple keys at the same level in the config are being overwritten. Like it's described in #464.

The tests passed, except for test 6 in help.t (`timew help with unknown argument should show error message`) but that seems unrelated.

I searched for unwanted side effects of this fix, but as far as I could find there are no duplicate keys in a config file at the same level.

If you wish for a different fix; please say so and I will do rework.

Fixes #464 