### PR TITLE
allow specification of intervals to `export` command

### DIFF
--- a/doc/man1/timew-export.1.adoc
+++ b/doc/man1/timew-export.1.adoc
@@ -5,13 +5,13 @@ timew-export - export tracked time in JSON
 
 == SYNOPSIS
 [verse]
-*timew export* [_<range>_] [_<tag>_**...**]
+*timew export* [_<id>_**...**] | [[_<range>_] [_<tag>_**...**]]
 
 == DESCRIPTION
-Exports all the tracked time in JSON format.
-Supports filtering.
+Exports all the tracked time in JSON format.  Supply either a list of interval IDs (e.g. `@1 @2`), or optional filters (see **timew-ranges(7)** and/or **timew-tags(1)**)
 
 == EXAMPLES
 For example:
 
     $ timew export from 2016-01-01 for 3wks tag1
+    $ timew export @1 @3 @7

--- a/test/export.t
+++ b/test/export.t
@@ -48,6 +48,17 @@ class TestExport(TestCase):
         code, out, err = self.t("export")
         self.assertIn("[\n]\n", out)
 
+    def test_fixed_id_export(self):
+        """Give specific IDs on CLI"""
+        self.t("track 2022-12-10T00:00:00Z - 2022-12-10T01:00:00Z")
+        self.t("track 2022-12-10T01:00:00Z - 2022-12-10T02:00:00Z")
+        self.t("track 2022-12-10T02:00:00Z - 2022-12-10T03:00:00Z")
+        self.t("track 2022-12-10T04:00:00Z - 2022-12-10T05:00:00Z")
+        j = self.t.export("@1 @4")
+        self.assertEqual(len(j), 2)
+        self.assertClosedInterval(j[0], expectedStart="20221210T000000Z", expectedId=4)
+        self.assertClosedInterval(j[1], expectedStart="20221210T040000Z", expectedId=1)
+
     def test_single_unobstructed_interval(self):
         """Single unobstructed interval"""
         now_utc = datetime.now().utcnow()


### PR DESCRIPTION
This adds feature to specify intervals, ie: `timew export @1 @2 @3`

If intervals are given, `export` will output only those numbered IDs in the JSON.  This allows user that already knows what IDs they want to request only those.  This capability is already available in Taskwarrior export.

Specifying both intervals and either tags or a range, is not allowed.  If the user did not already know what IDs they wanted they would be unable to give them, so it's probably not needed to allow both.  If there is a real scenario where ID set needs to be further narrowed, I'm not sure, so did not try to add that.

Fixes #510