### PR TITLE
Add workflow for Timewarrior Docker image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,53 @@
+name: Timewarrior Docker image
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [tests]
+    branches:
+      - develop
+      - stable
+    types:
+      - completed
+
+env:
+  REGISTRY: "ghcr.io"
+
+jobs:
+  build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2.8.1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Timewarrior Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          file: "./docker/timew.dockerfile"
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.actor }}/timew:${{ github.ref_name }}
+
+      - name: Sign the published Docker image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign ${{ env.REGISTRY }}/${{ github.actor }}/timew@${{ steps.build-and-push.outputs.digest }}

--- a/docker/timew.dockerfile
+++ b/docker/timew.dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:22.04 AS base
+
+FROM base AS builder
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN ( apt-get update && yes | unminimize ) && \
+    apt-get install -y \
+            cmake \
+            g++ \
+            git
+
+# Setup language environment
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Add source directory
+ADD .. /root/code/
+WORKDIR /root/code/
+
+# Build Timewarrior
+RUN git clean -dfx && \
+    git submodule init && \
+    git submodule update && \
+    cmake -DCMAKE_BUILD_TYPE=release . && \
+    make -j8
+
+FROM base AS runner
+
+# Install Timewarrior
+COPY --from=builder /root/code/src/timew /usr/local/bin
+
+# Initialize Timewarrior
+RUN timew :yes


### PR DESCRIPTION
Add a GitHub workflow to create a Docker image with a Timewarrior installation

The workflow is triggered by a successful run of the test suite and creates a Docker image with a Timewarrior installation of the current branch (restricted to develop/stable)

Signed-off-by: Thomas Lauf <thomas.lauf@tngtech.com>