### PR TITLE
Fix summary truncating multibyte characters in long anotations

### DIFF
--- a/src/commands/CmdSummary.cpp
+++ b/src/commands/CmdSummary.cpp
@@ -34,6 +34,7 @@
 #include <IntervalFilterAndGroup.h>
 #include <IntervalFilterAllWithTags.h>
 #include <IntervalFilterAllInRange.h>
+#include <utf8.h>
 
 // Implemented in CmdChart.cpp.
 std::map <Datetime, std::string> createHolidayMap (Rules&, Interval&);
@@ -229,9 +230,9 @@ int CmdSummary (
       {
         auto annotation = track.getAnnotation ();
 
-        if (annotation.length () > 15)
+        if (utf8_length (annotation) > 15)
         {
-          annotation = annotation.substr (0, 12) + "...";
+          annotation = utf8_substr (annotation, 0, 12) + "...";
         }
 
         table.set (row, annotation_col_index, annotation);

--- a/test/summary.t
+++ b/test/summary.t
@@ -352,6 +352,16 @@ W\d{1,2} \d{4}-\d{2}-\d{2} .{3}       ?0:00:00 0:00:00 0:00:00 0:00:00
 [ ]+0:00:00
 """)
 
+    def test_multibyte_char_annotation_truncated(self):
+        """Summary correctly truncates long annotation containing multibyte characters"""
+        # Using a blue heart emoji as an example of a multibyte (4 bytes in
+        # this case) character.
+        long_enough_annotation = "a" + "\N{blue heart}" * 20
+        self.t("track FOO sod - sod")
+        self.t("anno @1 " + long_enough_annotation)
+        code, out, err = self.t("summary :anno")
+        self.assertIn("a" + "\N{blue heart}" * 11 + "...", out)
+
 
 if __name__ == "__main__":
     from simpletap import TAPTestRunner


### PR DESCRIPTION
### Description

When calling `summary` command with `:annotations` hint, if the annotation is longer than a certain length, it's going to be truncated. The issue is that the length and truncation are done on a raw string without considering UTF8 multibyte characters, so there are edge cases when an annotation is truncated in the middle of a character creating an invalid UTF8 string.

Fixes #485.

### Notes

~~The fix is trivial, but~~ I have doubts about the test case - I wrote whatever the first thing which came to my mind. Open to feedback in that regard.

Based on the context, we might want to use `utf8_width`, because we care more about how wide the text appears in the output. However, since we can't (or I don't know how to) split the text by width, but we do it by length of characters, I decided to use `utf8_length`. I can see that `libshared` also implements `utf8_text_{length,width}` functions, however as far as I can tell the main difference it that they can filter out the colors, which I don't think matters in this context.

There is one test that is failing for me locally on the clean `develop` branch, so if CI is failing, it might be due to it.