### PR TITLE
Fix man page build for out-of-source builds

### DIFF
--- a/doc/man1/CMakeLists.txt
+++ b/doc/man1/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required (VERSION 2.8.12)
 
-file (GLOB DOC_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/*.1.adoc")
+file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.1.adoc")
 set (DOC_FILES)
 
 foreach (SRC ${DOC_SOURCES})
   string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
+  string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
 
   add_custom_command (
           OUTPUT "${OUTPUT_FILE_NAME}"

--- a/doc/man7/CMakeLists.txt
+++ b/doc/man7/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required (VERSION 2.8.12)
 
-file (GLOB DOC_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/*.7.adoc")
+file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.7.adoc")
 set (DOC_FILES)
 
 foreach (SRC ${DOC_SOURCES})
   string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
+  string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
 
   add_custom_command (
           OUTPUT "${OUTPUT_FILE_NAME}"


### PR DESCRIPTION
Fixes #461

The source files for asciidoctor need to be looked up in the `SOURCE_DIR`, and the output for them should be in the `BINARY_DIR`. Since they are identical for in-source builds, the previous version worked as well in those cases.