### PR TITLE
Extend XDG support to macOS

### DIFF
--- a/doc/man7/timew-config.7.adoc
+++ b/doc/man7/timew-config.7.adoc
@@ -7,7 +7,7 @@ timew-config - Timewarrior configuration file and override options
 **timew rc.**__<name>__**=**__<value>__ _<command>_
 
 == DESCRIPTION
-Timewarrior stores its configuration in the user's home directory in _~/.timewarrior/timewarrior.cfg_ on non-Unix systems (e.g. Windows or macOS).
+Timewarrior stores its configuration in the user's home directory in _~/.timewarrior/timewarrior.cfg_ on non-Unix systems (e.g. Windows).
 
 On Unix systems, XDG Base Directory specification is supported, if _~/.timewarrior_ directory doesn't exist
 (old config directory is still supported and has precedence over XDG BD compliant locations).

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -9,7 +9,7 @@ static const char *legacy_config_dir = "~/.timewarrior";
 static const bool uses_legacy_config = Directory (legacy_config_dir).exists ();
 const char *timewarriordb = getenv ("TIMEWARRIORDB");
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__) || defined(_SYSTYPE_BSD)
 std::string getPath (const char *xdg_path)
 {
   if (timewarriordb != nullptr)


### PR DESCRIPTION
I was a little mad about #207 not supporting macOS and the docs stating that macOS is a non-unix system. So I just made a tiny pull request to remedy this. I very much appreciate the work done by the original PR author, so I apologize if my comment on his PR was a bit too strongly worded. I am also not really sure why this feature should be limited to UNIX at all, but I leave this up to the maintainer.