### PR TITLE
README - Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Building Timewarrior yourself requires
 
 There are two ways to retrieve the Timewarrior sources:
 
-* Clone the repository from GitHub,
+* Clone the repository from GitHub and update required submodules,
   ```
   git clone --recurse-submodules https://github.com/GothenburgBitFactory/timewarrior
   cd timewarrior


### PR DESCRIPTION
Tried to build timewarrior from source for the first time using the instructions in the README. I missed seeing the `--recurse-submodules` for the clone option and suggesting an updated instruction line to better highlight that.