### PR TITLE
Fix py3.12 warnings for datetime usage, non-raw regex strings

### DIFF
--- a/test/annotate.t
+++ b/test/annotate.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ class TestAnnotate(TestCase):
 
     def test_add_annotation_to_open_interval(self):
         """Add an annotation to an open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -58,7 +59,7 @@ class TestAnnotate(TestCase):
 
     def test_should_use_default_on_missing_id_and_active_time_tracking(self):
         """Use open interval when adding annotation with missing id and active time tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -81,7 +82,7 @@ class TestAnnotate(TestCase):
 
     def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
         """Adding annotation with missing id on inactive time tracking is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -92,7 +93,7 @@ class TestAnnotate(TestCase):
 
     def test_remove_annotation_from_interval(self):
         """Calling 'annotate' without annotation removes annotation"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -106,7 +107,7 @@ class TestAnnotate(TestCase):
 
     def test_add_annotation_to_closed_interval(self):
         """Add an annotation to a closed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -120,7 +121,7 @@ class TestAnnotate(TestCase):
 
     def test_add_annotation_to_multiple_intervals(self):
         """Add an annotation to multiple intervals"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -141,7 +142,7 @@ class TestAnnotate(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
@@ -166,7 +167,7 @@ class TestAnnotate(TestCase):
 
     def test_annotate_with_identical_ids(self):
         """Call 'annotate' with identical ids"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -179,7 +180,7 @@ class TestAnnotate(TestCase):
 
     def test_annotate_with_embedded_quotes(self):
         """Call 'annotate' with embedded quotes"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -198,7 +199,7 @@ class TestAnnotate(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)

--- a/test/cancel.t
+++ b/test/cancel.t
@@ -29,7 +29,7 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +44,7 @@ class TestCancel(TestCase):
 
     def test_cancel_inactive_time_tracking(self):
         """Verify cancelling inactive time tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
@@ -72,7 +72,7 @@ class TestCancel(TestCase):
 
     def test_cancel_active_time_tracking(self):
         """Verify cancelling active time tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
 

--- a/test/cli.t
+++ b/test/cli.t
@@ -31,7 +31,7 @@ import os
 import shutil
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -60,7 +60,7 @@ class TestCLI(TestCase):
 
     def test_tag_database_is_recreated(self):
         """Verify that calling 'timew' recreates tag database"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         four_hours_before_utc = now_utc - timedelta(hours=4)
         three_hours_before_utc = now_utc - timedelta(hours=3)

--- a/test/continue.t
+++ b/test/continue.t
@@ -29,7 +29,7 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -136,7 +136,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_tag_without_active_tracking(self):
         """Verify that continuing a specified interval works"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -174,7 +174,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_tag_with_active_tracking(self):
         """Verify that continuing a specified interval stops active tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -218,7 +218,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_tag_and_date(self):
         """Verify that continuing an interval specified by tag with date continues at given date"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -259,7 +259,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_tag_and_range(self):
         """Verify that continue an interval specified by tag with a range adds a copy with same tags at given range"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
@@ -308,7 +308,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_id_and_date(self):
         """Verify that continuing a specified interval with date continues at given date"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -349,7 +349,7 @@ class TestContinue(TestCase):
 
     def test_continue_without_adjust_hint(self):
         """Verify that continuing without the :adjust hint fails to overwrite"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -363,7 +363,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_adjust_hint(self):
         """Verify that continuing with the :adjust hint works"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -395,7 +395,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_id_is_idempotent(self):
         """Verify that continuing with id is idempotent"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -427,7 +427,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_tag_is_idempotent(self):
         """Verify that continuing with id is idempotent"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -459,7 +459,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_id_and_range(self):
         """Verify that continue with a range adds a copy with same tags"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
@@ -503,7 +503,7 @@ class TestContinue(TestCase):
 
     def test_continue_with_future_time(self):
         """Verify that continue fails with time in the future"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)

--- a/test/delete.t
+++ b/test/delete.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ class TestDelete(TestCase):
 
     def test_delete_open(self):
         """Delete a single open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         five_hours_before_utc = now_utc - timedelta(hours=5)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -68,7 +69,7 @@ class TestDelete(TestCase):
 
     def test_delete_closed(self):
         """Delete a single closed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         five_hours_before_utc = now_utc - timedelta(hours=5)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -92,7 +93,7 @@ class TestDelete(TestCase):
 
     def test_delete_multiple(self):
         """Delete a mix of open/closed intervals"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         five_hours_before_utc = now_utc - timedelta(hours=5)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -113,7 +114,7 @@ class TestDelete(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
 

--- a/test/dom.t
+++ b/test/dom.t
@@ -30,7 +30,7 @@ import os
 import sys
 import unittest
 
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -174,7 +174,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_tags_with_no_tags(self):
         """Test 'dom.tracked.tags' with no tags"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
 
@@ -185,7 +185,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_tags_with_tags(self):
         """Test 'dom.tracked.tags' with tags"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
@@ -199,7 +199,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_tags_with_quoted_tag(self):
         """Test 'dom.tracked.tags' with a tag with quotes"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
@@ -213,7 +213,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_tags_filtered_by_time(self):
         """Test 'dom.tracked.tags' with tags filtered by time"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -229,7 +229,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_tags_filtered_by_tag(self):
         """Test 'dom.tracked.tags' with tags filtered by tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -250,7 +250,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_ids(self):
         """Test 'dom.tracked.ids'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
 
@@ -261,7 +261,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_ids_filtered_by_time(self):
         """Test 'dom.tracked.ids' filtered by time"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -277,7 +277,7 @@ class TestDOMTracked(TestCase):
 
     def test_dom_tracked_ids_filtered_by_tag(self):
         """Test 'dom.tracked.ids' filtered by tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)

--- a/test/export.t
+++ b/test/export.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -60,7 +61,7 @@ class TestExport(TestCase):
 
     def test_single_unobstructed_interval(self):
         """Single unobstructed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo".format(one_hour_before_utc, now_utc))
@@ -75,7 +76,7 @@ class TestExport(TestCase):
     def test_changing_exclusion_does_not_change_flattened_intervals(self):
         """Changing exclusions does not change flattened intervals"""
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         two_hours_before = now - timedelta(hours=2)
         three_hours_before = now - timedelta(hours=3)
@@ -123,7 +124,7 @@ class TestExport(TestCase):
     def test_changing_exclusion_does_change_open_interval(self):
         """Changing exclusions does change open interval"""
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         two_hours_before = now - timedelta(hours=2)
         three_hours_before = now - timedelta(hours=3)
@@ -168,7 +169,7 @@ class TestExport(TestCase):
 
     def test_export_with_tag_with_spaces(self):
         """Interval with tag with spaces"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z \"tag with spaces\"".format(one_hour_before_utc, now_utc))
@@ -180,7 +181,7 @@ class TestExport(TestCase):
 
     def test_export_with_tag_with_quote(self):
         """Interval with tag with quote"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z \"tag with \\\"quote\"".format(one_hour_before_utc, now_utc))

--- a/test/extensions.t
+++ b/test/extensions.t
@@ -3,7 +3,8 @@ import json
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 ###############################################################################
 #
@@ -64,7 +65,7 @@ class TestExtensions(TestCase):
         self.t.config("reports.debug.range", "'day'")
 
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         yesterday_one_hour_before_utc = now_utc - timedelta(hours=1, days=1)
         yesterday_two_hours_before_utc = now_utc - timedelta(hours=2, days=1)
@@ -88,7 +89,7 @@ class TestExtensions(TestCase):
         self.t.config("reports.debug.range", "'day'")
 
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         yesterday_one_hour_before_utc = now_utc - timedelta(hours=1, days=1)
         yesterday_two_hours_before_utc = now_utc - timedelta(hours=2, days=1)

--- a/test/join.t
+++ b/test/join.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -45,7 +46,7 @@ class TestJoin(TestCase):
     def test_join_closed_intervals(self):
         """Join two closed intervals"""
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
@@ -70,7 +71,7 @@ class TestJoin(TestCase):
     def test_join_closed_and_open_interval(self):
         """Join closed and open interval"""
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)

--- a/test/lengthen.t
+++ b/test/lengthen.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -57,7 +58,7 @@ class TestLengthen(TestCase):
     def test_lengthen_synthetic_interval(self):
         """Lengthen a synthetic interval."""
         now = datetime.now()
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
 
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)

--- a/test/modify.t
+++ b/test/modify.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -43,7 +44,7 @@ class TestModify(TestCase):
 
     def test_modify_end_of_open_interval(self):
         """Attempt to modify end of an open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -52,7 +53,7 @@ class TestModify(TestCase):
 
     def test_modify_start_of_open_interval(self):
         """Modify start of open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc))
@@ -65,7 +66,7 @@ class TestModify(TestCase):
 
     def test_modify_invalid_subcommand(self):
         """Modify without (start|stop) subcommand"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -75,7 +76,7 @@ class TestModify(TestCase):
 
     def test_modify_no_end_time(self):
         """Modify without a time to stop at"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -85,7 +86,7 @@ class TestModify(TestCase):
 
     def test_modify_shorten_one_hour(self):
         """Shorten the interval by one hour."""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=3)))
         self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=1)))
@@ -102,7 +103,7 @@ class TestModify(TestCase):
 
     def test_modify_shorten_before_start(self):
         """Modify should not move end before start."""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=3)))
         self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=1)))
@@ -114,7 +115,7 @@ class TestModify(TestCase):
 
     def test_modify_start_to_after_end(self):
         """Modify should not move start beyond end."""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=3)))
         self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=1)))
@@ -126,7 +127,7 @@ class TestModify(TestCase):
 
     def test_modify_start_within_interval(self):
         """Increase start time within interval."""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=3)))
         self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=1)))
@@ -143,7 +144,7 @@ class TestModify(TestCase):
 
     def test_modify_move_stop_to_overlap_following_interval(self):
         """Move end time to overlap with following interval."""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=3)))
         self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=1)))
@@ -155,7 +156,7 @@ class TestModify(TestCase):
 
     def test_modify_move_start_to_overlap_preceeding_interval(self):
         """Move start time to overlap with preceeding interval."""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=3)))
         self.t("stop {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc - timedelta(hours=1)))
@@ -172,7 +173,7 @@ class TestModify(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
         day_before = now_utc - timedelta(days=1)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
@@ -212,7 +213,7 @@ class TestModify(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
         day_before = now_utc - timedelta(days=1)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
@@ -255,7 +256,7 @@ class TestModify(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
         four_hours_before_utc = now_utc - timedelta(hours=4)
 
         self.t.configure_exclusions((four_hours_before.time(), three_hours_before.time()))

--- a/test/move.t
+++ b/test/move.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -86,7 +87,7 @@ class TestMove(TestCase):
         now = datetime.now()
         five_hours_before = now - timedelta(hours=5)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         five_hours_before_utc = now_utc - timedelta(hours=5)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -107,7 +108,7 @@ class TestMove(TestCase):
         now = datetime.now()
         two_hours_before = now - timedelta(hours=2)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         five_hours_before_utc = now_utc - timedelta(hours=5)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -150,7 +151,7 @@ class TestMove(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
@@ -180,7 +181,7 @@ class TestMove(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
@@ -210,7 +211,7 @@ class TestMove(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         day_before = now_utc - timedelta(days=1)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)

--- a/test/retag.t
+++ b/test/retag.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ class TestTag(TestCase):
 
     def test_should_use_default_on_missing_id_and_active_time_tracking(self):
         """Use open interval when retagging with missing id and active time tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -67,7 +68,7 @@ class TestTag(TestCase):
 
     def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
         """Retagging with missing id on inactive time tracking is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -78,7 +79,7 @@ class TestTag(TestCase):
 
     def test_should_fail_on_no_tags(self):
         """Calling command 'retag' without tags is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -89,7 +90,7 @@ class TestTag(TestCase):
 
     def test_retag_tagless_closed_interval_with_single_tag(self):
         """Retag a tagless, closed interval with a single tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -103,7 +104,7 @@ class TestTag(TestCase):
 
     def test_retag_tagless_closed_interval_with_multiple_tags(self):
         """Retag a tagless, closed interval with multiple tags"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -117,7 +118,7 @@ class TestTag(TestCase):
 
     def test_retag_tagless_open_interval_with_single_tag(self):
         """Retag a tagless, open interval with a single tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -131,7 +132,7 @@ class TestTag(TestCase):
 
     def test_retag_tagless_open_interval_with_multiple_tags(self):
         """Retag a tagless, open interval with multiple tags"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -145,7 +146,7 @@ class TestTag(TestCase):
 
     def test_retag_tagged_open_interval_with_single_tag(self):
         """Retag a tagged, open interval with a single tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z foo".format(one_hour_before_utc))
@@ -159,7 +160,7 @@ class TestTag(TestCase):
 
     def test_retag_tagged_open_interval_with_multiple_tags(self):
         """Retag a tagged, open interval with a single tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z foo".format(one_hour_before_utc))
@@ -173,7 +174,7 @@ class TestTag(TestCase):
 
     def test_retag_tagged_closed_interval_with_single_tag(self):
         """Retag a tagged, closed interval with a single tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo".format(one_hour_before_utc, now_utc))
@@ -187,7 +188,7 @@ class TestTag(TestCase):
 
     def test_retag_tagged_closed_interval_with_multiple_tags(self):
         """Retag a tagged, closed interval with multiple tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo bar".format(one_hour_before_utc, now_utc))
@@ -201,7 +202,7 @@ class TestTag(TestCase):
 
     def test_retag_multiple_intervals_with_single_tag(self):
         """Retag multiple intervals with a single tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -218,7 +219,7 @@ class TestTag(TestCase):
 
     def test_retag_multiple_intervals_with_multiple_tags(self):
         """Retag multiple intervals with multiple tags"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -239,7 +240,7 @@ class TestTag(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
@@ -264,7 +265,7 @@ class TestTag(TestCase):
 
     def test_retag_with_identical_ids(self):
         """Call 'retag' with identical ids"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -277,7 +278,7 @@ class TestTag(TestCase):
 
     def test_retag_with_new_tag(self):
         """Call 'retag' with new tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         one_hour_before_utc = now_utc - timedelta(hours=1)
@@ -290,7 +291,7 @@ class TestTag(TestCase):
 
     def test_retag_with_previous_tag(self):
         """Call 'retag' with previous tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         three_hours_before_utc = now_utc - timedelta(hours=3)
         two_hours_before_utc = now_utc - timedelta(hours=2)

--- a/test/shorten.t
+++ b/test/shorten.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta, time
+from datetime import datetime, timezone, timedelta, time
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -74,7 +75,7 @@ class TestShorten(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)

--- a/test/start.t
+++ b/test/start.t
@@ -29,7 +29,7 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta, time
+from datetime import datetime, timezone, timedelta, time
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -53,7 +53,7 @@ class TestStart(TestCase):
 
     def test_timed_start_past(self):
         """Test timed start past"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
@@ -68,7 +68,7 @@ class TestStart(TestCase):
 
     def test_timed_start_future(self):
         """Test timed start future"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         one_hour_after_utc = now_utc + timedelta(hours=1)
 
@@ -131,7 +131,7 @@ class TestStart(TestCase):
 
     def test_start_with_same_tags_as_current_tracking(self):
         """Test 'start' with same tags as current tracking should not start new tracking"""
-        utc_now = datetime.now().utcnow()
+        utc_now = datetime.now(timezone.utc)
         one_hour_ago_utc = utc_now - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z bar foo".format(one_hour_ago_utc))
@@ -225,7 +225,7 @@ class TestStart(TestCase):
 
     def test_start_with_new_tag(self):
         """Call 'start' with new tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         one_hour_before_utc = now_utc - timedelta(hours=1)
@@ -238,7 +238,7 @@ class TestStart(TestCase):
 
     def test_start_with_previous_tag(self):
         """Call 'start' with previous tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         three_hours_before_utc = now_utc - timedelta(hours=3)
         two_hours_before_utc = now_utc - timedelta(hours=2)

--- a/test/stop.t
+++ b/test/stop.t
@@ -30,7 +30,7 @@ import os
 import sys
 import unittest
 
-from datetime import datetime, timedelta, time
+from datetime import datetime, timezone, timedelta, time
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -45,7 +45,7 @@ class TestStop(TestCase):
 
     def test_timed_stop(self):
         """Test timed stop"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -60,7 +60,7 @@ class TestStop(TestCase):
 
     def test_stop_with_end_before_start_is_an_error(self):
         """Verify stop date before start date is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(now_utc))

--- a/test/summary.t
+++ b/test/summary.t
@@ -57,7 +57,7 @@ class TestSummary(TestCase):
 
         code, out, err = self.t("summary :ids {:%Y-%m-%d} - {:%Y-%m-%d}".format(yesterday, tomorrow))
 
-        self.assertRegex(out, """
+        self.assertRegex(out, r"""
 Wk  ?Date       Day ID Tags    ?Start      ?End    Time   Total
 [ -]+
 W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2}(
@@ -76,7 +76,7 @@ W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2
 
         code, out, err = self.t("summary :ids :all".format(yesterday, tomorrow))
 
-        self.assertRegex(out, """
+        self.assertRegex(out, r"""
 Wk  ?Date       Day ID Tags    ?Start      ?End    Time   Total
 [ -]+
 W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2}(
@@ -95,7 +95,7 @@ W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2
 
         code, out, err = self.t("summary :ids {:%Y-%m-%d} - {:%Y-%m-%d}".format(yesterday, tomorrow))
 
-        self.assertRegex(out, """
+        self.assertRegex(out, r"""
 Wk  ?Date       Day ID Tags    ?Start End    Time   Total
 [ -]+
 W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2}[ ]+- \d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2}(
@@ -114,7 +114,7 @@ W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2}[ ]+- \d{1,2}:\d{2}
 
         code, out, err = self.t("summary :ids :all".format(yesterday, tomorrow))
 
-        self.assertRegex(out, """
+        self.assertRegex(out, r"""
 Wk  ?Date       Day ID Tags    ?Start End    Time   Total
 [ -]+
 W\d{1,2} \d{4}-\d{2}-\d{2} .{3} @1       ?\d{1,2}:\d{2}:\d{2}[ ]+- \d{1,2}:\d{2}:\d{2} \d{1,2}:\d{2}:\d{2}(
@@ -362,7 +362,7 @@ W10 2017-03-11 Sat @3 FOO  10:00:00 11:00:00 1:00:00
         """Summary should display empty intervals at midnight"""
         self.t("track sod - sod")
         code, out, err = self.t("summary :year")
-        self.assertRegex(out, """
+        self.assertRegex(out, r"""
 Wk  ?Date       Day Tags    ?Start      ?End    Time   Total
 [ -]+
 W\d{1,2} \d{4}-\d{2}-\d{2} .{3}       ?0:00:00 0:00:00 0:00:00 0:00:00

--- a/test/tag.t
+++ b/test/tag.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ class TestTag(TestCase):
 
     def test_add_tag_to_open_interval(self):
         """Add a tag to an open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -58,7 +59,7 @@ class TestTag(TestCase):
 
     def test_should_use_default_on_missing_id_and_active_time_tracking(self):
         """Use open interval when adding tags with missing id and active time tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -81,7 +82,7 @@ class TestTag(TestCase):
 
     def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
         """Adding tag with missing id on inactive time tracking is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -92,7 +93,7 @@ class TestTag(TestCase):
 
     def test_should_fail_on_no_tags(self):
         """Calling command 'tag' without tags is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -103,7 +104,7 @@ class TestTag(TestCase):
 
     def test_add_tag_to_closed_interval(self):
         """Add a tag to a closed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -117,7 +118,7 @@ class TestTag(TestCase):
 
     def test_add_tags_to_open_interval(self):
         """Add tags to an open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc))
@@ -131,7 +132,7 @@ class TestTag(TestCase):
 
     def test_add_tags_to_closed_interval(self):
         """Add tags to a closed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -145,7 +146,7 @@ class TestTag(TestCase):
 
     def test_add_tag_to_multiple_intervals(self):
         """Add a tag to multiple intervals"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -162,7 +163,7 @@ class TestTag(TestCase):
 
     def test_add_tags_to_multiple_intervals(self):
         """Add tags to multiple intervals"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -183,7 +184,7 @@ class TestTag(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
@@ -218,7 +219,7 @@ class TestTag(TestCase):
 
     def test_tag_with_identical_ids(self):
         """Call 'tag' with identical ids"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -231,7 +232,7 @@ class TestTag(TestCase):
 
     def test_tag_with_new_tag(self):
         """Call 'tag' with new tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         one_hour_before_utc = now_utc - timedelta(hours=1)
@@ -244,7 +245,7 @@ class TestTag(TestCase):
 
     def test_tag_with_previous_tag(self):
         """Call 'tag' with previous tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         three_hours_before_utc = now_utc - timedelta(hours=3)
         two_hours_before_utc = now_utc - timedelta(hours=2)

--- a/test/tags.t
+++ b/test/tags.t
@@ -29,7 +29,7 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -50,7 +50,7 @@ class TestTags(TestCase):
 
     def test_tags_listed(self):
         """Test the two tags used are both listed"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hour_before_utc = now_utc - timedelta(hours=2)
 

--- a/test/test_totals.t
+++ b/test/test_totals.t
@@ -26,7 +26,8 @@
 #
 ###############################################################################
 
-import datetime
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 import os
 import sys
 import unittest
@@ -36,7 +37,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'ext'))
 
 from basetest import TestCase
-from totals import *
+from totals import format_seconds, calculate_totals
 
 
 class TestTotals(TestCase):
@@ -57,11 +58,11 @@ class TestTotals(TestCase):
 
     def test_totals_with_filled_database(self):
         """totals extension should print report for filled database"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: off\n',
@@ -90,11 +91,11 @@ class TestTotals(TestCase):
 
     def test_totals_with_time_delta_larger_than_24_hours(self):
         """totals extension should print report for time delta larger than 24 hours"""
-        now = datetime.datetime.now()
-        two_days_before = now - datetime.timedelta(days=2)
+        now = datetime.now()
+        two_days_before = now - timedelta(days=2)
 
-        now_utc = now.utcnow()
-        two_days_before_utc = now_utc - datetime.timedelta(days=2)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        two_days_before_utc = now_utc - timedelta(days=2)
 
         input_stream = [
             'color: off\n',
@@ -123,11 +124,11 @@ class TestTotals(TestCase):
 
     def test_totals_with_emtpy_range(self):
         """totals extension should report error on emtpy range"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: off\n',
@@ -144,11 +145,11 @@ class TestTotals(TestCase):
 
     def test_totals_with_interval_without_tags(self):
         """totals extension should handle interval without tags"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: off\n',
@@ -177,11 +178,11 @@ class TestTotals(TestCase):
 
     def test_totals_with_interval_with_empty_tag_list(self):
         """totals extension should handle interval with empty tag list"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: off\n',
@@ -210,11 +211,11 @@ class TestTotals(TestCase):
 
     def test_totals_with_open_interval(self):
         """totals extension should handle open interval"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: off\n',
@@ -258,11 +259,11 @@ class TestTotals(TestCase):
 
     def test_totals_colored_with_filled_database(self):
         """totals extension should print report for filled database (colored)"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: on\n',
@@ -290,11 +291,11 @@ class TestTotals(TestCase):
 
     def test_totals_colored_with_emtpy_range(self):
         """totals extension should report error on emtpy range (colored)"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: on\n',
@@ -311,11 +312,11 @@ class TestTotals(TestCase):
 
     def test_totals_colored_with_interval_without_tags(self):
         """totals extension should handle interval without tags (colored)"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: on\n',
@@ -343,11 +344,11 @@ class TestTotals(TestCase):
 
     def test_totals_colored_with_interval_with_empty_tag_list(self):
         """totals extension should handle interval with empty tag list (colored)"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: on\n',
@@ -375,11 +376,11 @@ class TestTotals(TestCase):
 
     def test_totals_colored_with_open_interval(self):
         """totals extension should handle open interval (colored)"""
-        now = datetime.datetime.now()
-        one_hour_before = now - datetime.timedelta(hours=1)
+        now = datetime.now()
+        one_hour_before = now - timedelta(hours=1)
 
-        now_utc = now.utcnow()
-        one_hour_before_utc = now_utc - datetime.timedelta(hours=1)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
 
         input_stream = [
             'color: on\n',

--- a/test/track.t
+++ b/test/track.t
@@ -30,7 +30,7 @@ import os
 import sys
 import unittest
 
-from datetime import datetime, timedelta, time
+from datetime import datetime, timezone, timedelta, time
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -101,7 +101,7 @@ class TestTrack(TestCase):
 
     def test_track_with_new_tag(self):
         """Call 'track' with new tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         one_hour_before_utc = now_utc - timedelta(hours=1)
@@ -114,7 +114,7 @@ class TestTrack(TestCase):
 
     def test_track_with_previous_tag(self):
         """Call 'track' with previous tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_before_utc = now_utc - timedelta(hours=2)
         one_hour_before_utc = now_utc - timedelta(hours=1)
@@ -127,7 +127,7 @@ class TestTrack(TestCase):
 
     def test_track_with_future_time(self):
         """Test track with future interval is not an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         two_hours_after_utc = now_utc + timedelta(hours=2)
         one_hour_after_utc = now_utc + timedelta(hours=1)
@@ -145,7 +145,7 @@ class TestTrack(TestCase):
 
     def test_track_with_adjust_should_overwrite_enclosed_interval_with_same_start(self):
         """Command track with adjust should overwrite enclosed interval with same start"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         four_hours_before = now_utc - timedelta(hours=4)
         three_hours_before = now_utc - timedelta(hours=3)
@@ -164,7 +164,7 @@ class TestTrack(TestCase):
 
     def test_track_with_adjust_should_overwrite_enclosed_interval_with_same_end(self):
         """Command track with adjust should overwrite enclosed interval with same end"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         five_hours_before = now_utc - timedelta(hours=5)
         four_hours_before = now_utc - timedelta(hours=4)
@@ -183,7 +183,7 @@ class TestTrack(TestCase):
 
     def test_track_with_adjust_should_overwrite_identical_interval(self):
         """Command track with adjust should overwrite identical interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
 
         four_hours_before = now_utc - timedelta(hours=4)
         three_hours_before = now_utc - timedelta(hours=3)

--- a/test/undo.t
+++ b/test/undo.t
@@ -28,7 +28,7 @@
 
 import os
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 import sys
 
@@ -45,7 +45,7 @@ class TestUndo(TestCase):
 
     def test_undo_annotate(self):
         """Test undo of command 'annotate'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -70,7 +70,7 @@ class TestUndo(TestCase):
 
     def test_undo_annotate_with_embedded_quotes(self):
         """Test undo of command 'annotate' with embedded quotes"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -100,7 +100,7 @@ class TestUndo(TestCase):
 
     def test_undo_cancel(self):
         """Test undo of command 'cancel'"""
-        one_hour_before_utc = datetime.now().utcnow() - timedelta(hours=1)
+        one_hour_before_utc = datetime.now(timezone.utc) - timedelta(hours=1)
 
         self.t("start {:%Y%m%dT%H%M%SZ} foo".format(one_hour_before_utc))
         self.t("cancel")
@@ -170,7 +170,7 @@ class TestUndo(TestCase):
 
     def test_undo_continue(self):
         """Test undo of command 'continue'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -198,7 +198,7 @@ class TestUndo(TestCase):
 
     def test_undo_delete(self):
         """Test undo of command 'delete'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -240,7 +240,7 @@ class TestUndo(TestCase):
 
     def test_undo_join(self):
         """Test undo of command 'join'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -275,7 +275,7 @@ class TestUndo(TestCase):
 
     def test_undo_lengthen(self):
         """Test undo of command 'lengthen'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -301,7 +301,7 @@ class TestUndo(TestCase):
 
     def test_undo_move(self):
         """Test undo of command 'move'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -327,7 +327,7 @@ class TestUndo(TestCase):
 
     def test_undo_resize(self):
         """Test undo of command 'resize'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -353,7 +353,7 @@ class TestUndo(TestCase):
 
     def test_undo_shorten(self):
         """Test undo of command 'shorten'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -379,7 +379,7 @@ class TestUndo(TestCase):
 
     def test_undo_split(self):
         """Test undo of command 'split'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -409,7 +409,7 @@ class TestUndo(TestCase):
 
     def test_undo_start(self):
         """Test undo of command 'start'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y%m%dT%H%M%SZ} foo".format(one_hour_before_utc))
@@ -427,7 +427,7 @@ class TestUndo(TestCase):
 
     def test_undo_consecutive_start(self):
         """Test undo of consecutive commands 'start'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -454,7 +454,7 @@ class TestUndo(TestCase):
 
     def test_undo_start_with_embedded_quotes_in_tag(self):
         """Test undo of 'start' with embedded quotes in tag"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -481,7 +481,7 @@ class TestUndo(TestCase):
 
     def test_undo_start_with_tag_enclosed_in_backslashes(self):
         """Test undo of 'start' with tag enclosed in backslashes"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y%m%dT%H%M%SZ} '\\foo\\'".format(one_hour_before_utc))
@@ -499,7 +499,7 @@ class TestUndo(TestCase):
 
     def test_undo_stop(self):
         """Test undo of command 'stop'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y%m%dT%H%M%SZ} foo".format(one_hour_before_utc))
@@ -522,7 +522,7 @@ class TestUndo(TestCase):
 
     def test_undo_tag(self):
         """Test undo of command 'tag'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -547,7 +547,7 @@ class TestUndo(TestCase):
 
     def test_undo_track(self):
         """Test undo of command 'track'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -578,7 +578,7 @@ class TestUndo(TestCase):
 
     def test_undo_track_with_adjust_hint(self):
         """Test undo of command 'track' with adjust hint"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
         three_hours_before_utc = now_utc - timedelta(hours=3)
@@ -612,7 +612,7 @@ class TestUndo(TestCase):
 
     def test_undo_untag(self):
         """Test undo of command 'untag'"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 

--- a/test/untag.t
+++ b/test/untag.t
@@ -29,7 +29,8 @@
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
+from dateutil import tz
 
 # Ensure python finds the local simpletap module
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ class TestUntag(TestCase):
 
     def test_remove_tag_from_open_interval(self):
         """Remove a tag from an open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z foo bar baz".format(one_hour_before_utc))
@@ -58,7 +59,7 @@ class TestUntag(TestCase):
 
     def test_should_use_default_on_missing_id_and_active_time_tracking(self):
         """Use open interval when removing tags with missing id and active time tracking"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -81,7 +82,7 @@ class TestUntag(TestCase):
 
     def test_should_fail_on_missing_id_and_inactive_time_tracking(self):
         """Removing tag with missing id on inactive time tracking is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -92,7 +93,7 @@ class TestUntag(TestCase):
 
     def test_should_fail_on_no_tags(self):
         """Calling command 'untag' without tags is an error"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(one_hour_before_utc, now_utc))
@@ -103,7 +104,7 @@ class TestUntag(TestCase):
 
     def test_remove_tag_from_closed_interval(self):
         """Remove a tag from a closed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo bar baz".format(one_hour_before_utc, now_utc))
@@ -117,7 +118,7 @@ class TestUntag(TestCase):
 
     def test_remove_tags_from_open_interval(self):
         """Remove tags from an open interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("start {:%Y-%m-%dT%H:%M:%S}Z foo bar baz".format(one_hour_before_utc))
@@ -131,7 +132,7 @@ class TestUntag(TestCase):
 
     def test_remove_tags_from_closed_interval(self):
         """Remove tags from a closed interval"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo bar baz".format(one_hour_before_utc, now_utc))
@@ -145,7 +146,7 @@ class TestUntag(TestCase):
 
     def test_remove_tag_from_multiple_intervals(self):
         """Remove a tag from multiple intervals"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -162,7 +163,7 @@ class TestUntag(TestCase):
 
     def test_remove_tags_from_multiple_intervals(self):
         """Remove tags from multiple intervals"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
         two_hours_before_utc = now_utc - timedelta(hours=2)
 
@@ -183,7 +184,7 @@ class TestUntag(TestCase):
         three_hours_before = now - timedelta(hours=3)
         four_hours_before = now - timedelta(hours=4)
 
-        now_utc = now.utcnow()
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)
         three_hours_before_utc = now_utc - timedelta(hours=3)
         four_hours_before_utc = now_utc - timedelta(hours=4)
         five_hours_before_utc = now_utc - timedelta(hours=5)
@@ -218,7 +219,7 @@ class TestUntag(TestCase):
 
     def test_untag_with_identical_ids(self):
         """Call 'untag' with identical ids"""
-        now_utc = datetime.now().utcnow()
+        now_utc = datetime.now(timezone.utc)
         one_hour_before_utc = now_utc - timedelta(hours=1)
 
         self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo bar".format(one_hour_before_utc, now_utc))


### PR DESCRIPTION
After upgrading my `python3` from `python-3.9` to `python-3.12`, running the `test` target causes a bunch of new warnings to be emitted.  These are regarding `datetime.datetime.utcnow()` being deprecated.  This is because upstream wants to make changes to naive datetimes (those without `tzdata`).

Here is the blurb from https://docs.python.org/3/whatsnew/3.12.html:

> datetime: datetime.datetime’s utcnow() and utcfromtimestamp() are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call now() and fromtimestamp() with the tz parameter set to datetime.UTC.

There is some discussion of upstream's rationale in python/cpython#81669.

For the fix, I chose to use `datetime.timezone.utc` rather than `datetime.UTC` because the latter was only added in `python-3.11` and I wanted the tests to work under both `python-3.9` and `python-3.12`.

The following edit sequences were run to produce the changes:

First, `test_totals.t` had imported all of `datetime`, unlike all the other files which were importing individual names `from datetime`.  It also did a wildcard import from `ext/totals.py` which caused a shadowing issue so I made the imports more specific.  Now taht file imports `datetime` like the others, so later mass-edits (below) will work on this file too:
```
sed -i \
-e 's/^.*totals.*\*/from totals import format_seconds, calculate_totals/' \
-e 's/^import.datetime$/from datetime import datetime, timedelta/' \
-e 's/datetime\.datetime\./datetime./g' \
-e 's/datetime\.timedelta/timedelta/' \
test/test_totals.t
```

Next, we replace the deprecated `utcnow()` with a tzinfo-aware call, which can be done directly by giving a zone argument to `now()` but in other uses, a tzinfo-naive object is obtained, used for some things, and then later its `.utcnow()` method is run.  We had to convert those uses in-place by first localizing:
```
grep -lsrF \
  -e 'datetime.now().utcnow()' \
  -e 'now.utcnow()' \
| xargs sed -i \
  -e 's/datetime.now().utcnow()/datetime.now(timezone.utc)/g' \
  -e '/import.datetime/a\' \
  -e 'from dateutil import tz' \
  -e 's/^\(from datetime import datetime,\)/\1 timezone,/' \
  -e 's/now.utcnow()/now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc)/'
```

Finally, I removed the `tzlocal` import from files that didn't need it because they didn't do a conversion from naive objects to a aware objects (in the transform above):
```
for file in $(grep -lsr 'from.dateutil.import.tz$' test)
do grep -q tzlocal $file || sed -i '/^from.dateutil.import.tz$/d' $file
done
```

Incidentally, there were some regexes in `summary.t` that are not raw-quoted, generating a warning on embedded `\d` in non-raw quoted strings.  These were probably already warnings before.  They were fixed en passant in a separate commit.

Please apply, thanks.
