### PR TITLE
Make week number parsing ISO8601 compliant

### DIFF
--- a/src/DatetimeParser.cpp
+++ b/src/DatetimeParser.cpp
@@ -2787,7 +2787,7 @@ bool DatetimeParser::isOrdinal (const std::string& token, int& ordinal)
 bool DatetimeParser::validate ()
 {
   // _year;
-  if ((_year    && (_year    <   1900 || _year    >                                  2200)) ||
+  if ((_year    && (_year    <   1900 || _year    >                                  9999)) ||
       (_month   && (_month   <      1 || _month   >                                    12)) ||
       (_week    && (_week    <      1 || _week    >                                    53)) ||
       (_weekday && (_weekday <      0 || _weekday >                                     6)) ||

--- a/src/DatetimeParser.cpp
+++ b/src/DatetimeParser.cpp
@@ -190,7 +190,7 @@ void DatetimeParser::clear ()
   _year    = 0;
   _month   = 0;
   _week    = 0;
-  _weekday = 0;
+  _weekday = Datetime::weekstart;
   _julian  = 0;
   _day     = 0;
   _seconds = 0;
@@ -462,18 +462,22 @@ bool DatetimeParser::parse_date_ext (Pig& pig)
     int month {};
     int day {};
     int julian {};
+    int week {};
+    int weekday {};
 
     if (pig.skip ('W') &&
-        parse_week (pig, _week))
+        parse_week (pig, week))
     {
-      if (pig.skip ('-') &&
-          pig.getDigit (_weekday))
+      if (! (pig.skip ('-') &&
+             parse_weekday (pig, weekday)))
       {
-        // What is happening here - must be something to do?
+        weekday = Datetime::weekstart;
       }
 
       if (! unicodeLatinDigit (pig.peek ()))
       {
+        _weekday = weekday;
+        _week = week;
         _year = year;
         return true;
       }
@@ -679,13 +683,14 @@ bool DatetimeParser::parse_date (Pig& pig)
     if (pig.skip ('W') &&
         parse_week (pig, week))
     {
-      if (pig.getDigit (weekday))
-        _weekday = weekday;
+      if (! (parse_weekday (pig, weekday)))
+        weekday = Datetime::weekstart;
 
       if (! unicodeLatinDigit (pig.peek ()))
       {
         _year = year;
         _week = week;
+        _weekday = weekday;
         return true;
       }
     }
@@ -926,8 +931,8 @@ bool DatetimeParser::parse_weekday (Pig& pig, int& value)
 
   int weekday;
   if (pig.getDigit (weekday) &&
-      weekday >= 1           &&
-      weekday <= 7)
+      weekday >= Datetime::weekstart &&
+      weekday <= (Datetime::weekstart == 1 ? 7 : 6))
   {
     value = weekday;
     return true;
@@ -2786,11 +2791,15 @@ bool DatetimeParser::isOrdinal (const std::string& token, int& ordinal)
 // Validation via simple range checking.
 bool DatetimeParser::validate ()
 {
+  // for ISO 8601 week specification: YYYY-Www-D where D is 1-7 (Mon-Sun)
+  int wks = (Datetime::weekstart == 1 ? 1: 0);
+  int wke = (Datetime::weekstart == 1 ? 7: 6);
+
   // _year;
   if ((_year    && (_year    <   1900 || _year    >                                  9999)) ||
       (_month   && (_month   <      1 || _month   >                                    12)) ||
       (_week    && (_week    <      1 || _week    >                                    53)) ||
-      (_weekday && (_weekday <      0 || _weekday >                                     6)) ||
+      (true     && (_weekday <    wks || _weekday >                                   wke)) ||
       (_julian  && (_julian  <      1 || _julian  >          Datetime::daysInYear (_year))) ||
       (_day     && (_day     <      1 || _day     > Datetime::daysInMonth (_year, _month))) ||
       (_seconds && (_seconds <      1 || _seconds >                                 86400)) ||
@@ -2807,7 +2816,7 @@ bool DatetimeParser::validate ()
 // int tm_mday;      day of month (1 - 31)
 // int tm_mon;       month of year (0 - 11)
 // int tm_year;      year - 1900
-// int tm_wday;      day of week (Sunday = 0)
+// int tm_wday;      day of week (0-6 or 1-7 depending on Datetime::weekstart)
 // int tm_yday;      day of year (0 - 365)
 // int tm_isdst;     is daylight saving time in effect?
 // char *tm_zone;    abbreviation of timezone name
@@ -2851,16 +2860,54 @@ void DatetimeParser::resolve ()
       month   == 0           &&
       day     == 0           &&
       week    == 0           &&
-      weekday == 0           &&
+      weekday == Datetime::weekstart &&
       seconds < seconds_now)
   {
     seconds += 86400;
   }
 
-  // Convert week + weekday --> julian.
+  // Convert week + weekday --> julian, possibly in the previous or next
+  // calendar year (for ISO8601 weeks).  Weekday will be 1-7 if weekstart = 1,
+  // as per ISO week spec.  This is incompatible with tm.tm_wday (which is
+  // 0-6, Sunday based), but that field is not assigned anywhere in this
+  // function, and note that mktime() uses tm_wday only as an output field.
+  // We use Datetime::weekstart as a hint about whether the user is
+  // giving/wants ISO weeks, although the very use of 2024-W30 and 2024-W30-1
+  // format is from ISO8601 in the first place.
+  //
   if (week)
   {
-    julian = (week * 7) + weekday - Datetime::dayOfWeek (year, 1, 4) - 3;
+    // Get 0-based (Sunday) and 1-based (Monday, ie ISO) dow for 4th Jan
+    // 0 Sun, 1 Mon, 2 Tue, 3 Wed, 4 Thu, 5 Fri, 6 Sat
+    //        1 Mon, 2 Tue, 3 Wed, 4 Thu, 5 Fri, 6 Sat, 7 Sun
+    //
+    int jan4dow0 = Datetime::dayOfWeek (year, 1, 4);
+    int jan4dow1 = (jan4dow0 == 0 ? 7 : jan4dow0);
+
+    if (Datetime::weekstart == 1)
+    {
+      // https://en.wikipedia.org/wiki/ISO_week_date
+      julian = week * 7 + weekday - (jan4dow1 + 3);
+      if (julian < 1)
+      {
+        julian += Datetime::daysInYear (--year);
+      }
+      else
+      {
+        int yeardays = Datetime::daysInYear (year);
+        if (julian > yeardays)
+        {
+          year++;
+          julian -= yeardays;
+        }
+      }
+    }
+    else
+    {
+      // Prior algorithm that was used for all weekstarts before, now only
+      // used for Sunday weekstarts
+      julian = week * 7 + weekday - jan4dow0 - 3;
+    }
   }
 
     // Provide default values for year, month, day.


### PR DESCRIPTION
This PR makes week number parsing ISO8601-compliant.  Previously, week numbers parsed as Sunday-based when given as `2024-W34`, and did not respect the ISO8601 algorithm for which year they were in.  This was inconsistent with `:week`, `:lastweek`, etc, which use Monday-based weeks.  This PR equalizes that inconsistency, and switches to the ISO standard algorithm for week numbers.

As a side effect, note that day number parsing (ie `2024-W34-1`) also changes from 0-6 Sunday to 1-7 Monday, again following ISO8601.  This only has a consequence for Sunday itself, which changes from day 0 to day 7.

**NOTE:** *These changes strictly duplicate* ones from GothenburgBitFactory/libshared#81.  Timewarrior contains duplicate implementations of several methods from libshared's `Datetime` class in its own `DatetimeParser` class.  All methods we have changed are identical in both places.  Eventually, the two classes are [intended be merged back together](https://github.com/GothenburgBitFactory/libshared/pull/81#issuecomment-2262105316).

The only difference with the libshared version of the patch is that we use libshared's `Datetime::dayOfWeek()` and `Datetime::daysInYear()` because they aren't among the copied methods in our `DatetimeParser` class.

Rationale and details, including references and links to standards, can be seen in the discussion and commits in libshared.

No tests were added to Timewarrior, as all my changes are already fully covered in new libshared tests, and all the existing tests here pass with no changes.

Fixes #595.
