### PR TITLE
Update test zoo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,10 +21,9 @@ jobs:
           - name: "Debian Stable"
             runner: ubuntu-latest
             container: debianstable
-# Pause testing on debian testing until libfiu-dev/fiu-utils is available
-#          - name: "Debian Testing"
-#            runner: ubuntu-latest
-#            container: debiantesting
+          - name: "Debian Testing"
+            runner: ubuntu-latest
+            container: debiantesting
           - name: "Fedora 37"
             runner: ubuntu-latest
             container: fedora37

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,9 +45,6 @@ jobs:
           - name: "Ubuntu 22.04"
             runner: ubuntu-latest
             container: ubuntu2204
-          - name: "macOS 12"
-            runner: macos-12
-            container: osx-12
           - name: "macOS 13"
             runner: macos-13
             container: osx-13


### PR DESCRIPTION
* Re-enable Debian Testing image
   Was disabled in 4c9a39aa3184694ad8aa55f7710ea38c7e2c952a because 'fiu-utils' was not available
* Remove 'macOS 12' runner
  GitHub is removing the `macOS 12` runner image by 2024-12-03
  See https://github.com/actions/runner-images/issues/10721