### PR TITLE
Fix installation of man pages from tarball

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -8,12 +8,9 @@ add_subdirectory (themes)
 if (ASCIIDOCTOR_FOUND)
   set (ASCIIDOCTOR_OPTIONS "--attribute=manmanual=User Manuals"
                            "--attribute=mansource=timew ${PROJECT_VERSION}")
-
-  add_subdirectory (man1)
-  add_subdirectory (man7)
-
-  add_custom_target (doc ALL DEPENDS man1 man7)
-else (ASCIIDOCTOR_FOUND)
-  add_custom_target (doc ALL
-                     COMMAND echo "Tool 'asciidoctor' is required to generate man pages! Please install it first.")
 endif (ASCIIDOCTOR_FOUND)
+
+add_subdirectory (man1)
+add_subdirectory (man7)
+
+add_custom_target (doc ALL DEPENDS man1 man7)

--- a/doc/man1/CMakeLists.txt
+++ b/doc/man1/CMakeLists.txt
@@ -4,21 +4,21 @@ if (ASCIIDOCTOR_FOUND)
   file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.1.adoc")
   set (DOC_FILES)
 
-  foreach (SRC ${DOC_SOURCES})
+  foreach (SRC IN LISTS DOC_SOURCES)
     string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
     string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
 
     add_custom_command (OUTPUT "${OUTPUT_FILE_NAME}"
-                        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} ${SRC} -o ${OUTPUT_FILE_NAME}
+                        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} "${SRC}" -o "${OUTPUT_FILE_NAME}"
                         DEPENDS "${SRC}")
 
-    set (DOC_FILES ${DOC_FILES} "${OUTPUT_FILE_NAME}")
+    list (APPEND DOC_FILES "${OUTPUT_FILE_NAME}")
   endforeach (SRC)
-else (ASCIIDOCTOR_FOUND)
-  file(GLOB MAN_PAGES "${CMAKE_CURRENT_SOURCE_DIR}/*.1")
-  set (DOC_FILES ${DOC_FILES} "${MAN_PAGES}")
-endif (ASCIIDOCTOR_FOUND)
 
-add_custom_target (man1 DEPENDS ${DOC_FILES})
+  add_custom_target (man1 DEPENDS ${DOC_FILES})
+else (ASCIIDOCTOR_FOUND)
+  file (GLOB MAN_PAGES "${CMAKE_CURRENT_SOURCE_DIR}/*.1")
+  set (DOC_FILES ${MAN_PAGES})
+endif (ASCIIDOCTOR_FOUND)
 
 install (FILES ${DOC_FILES} DESTINATION ${TIMEW_MAN1DIR})

--- a/doc/man1/CMakeLists.txt
+++ b/doc/man1/CMakeLists.txt
@@ -1,18 +1,23 @@
 cmake_minimum_required (VERSION 3.10)
 
-file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.1.adoc")
-set (DOC_FILES)
+if (ASCIIDOCTOR_FOUND)
+  file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.1.adoc")
+  set (DOC_FILES)
 
-foreach (SRC ${DOC_SOURCES})
-  string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
-  string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
+  foreach (SRC ${DOC_SOURCES})
+    string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
+    string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
 
-  add_custom_command (OUTPUT "${OUTPUT_FILE_NAME}"
-                      COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} ${SRC} -o ${OUTPUT_FILE_NAME}
-                      DEPENDS "${SRC}")
+    add_custom_command (OUTPUT "${OUTPUT_FILE_NAME}"
+                        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} ${SRC} -o ${OUTPUT_FILE_NAME}
+                        DEPENDS "${SRC}")
 
-  set (DOC_FILES ${DOC_FILES} "${OUTPUT_FILE_NAME}")
-endforeach (SRC)
+    set (DOC_FILES ${DOC_FILES} "${OUTPUT_FILE_NAME}")
+  endforeach (SRC)
+else (ASCIIDOCTOR_FOUND)
+  file(GLOB MAN_PAGES "${CMAKE_CURRENT_SOURCE_DIR}/*.1")
+  set (DOC_FILES ${DOC_FILES} "${MAN_PAGES}")
+endif (ASCIIDOCTOR_FOUND)
 
 add_custom_target (man1 DEPENDS ${DOC_FILES})
 

--- a/doc/man7/CMakeLists.txt
+++ b/doc/man7/CMakeLists.txt
@@ -4,21 +4,21 @@ if (ASCIIDOCTOR_FOUND)
   file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.7.adoc")
   set (DOC_FILES)
 
-  foreach (SRC ${DOC_SOURCES})
+  foreach (SRC IN LISTS DOC_SOURCES)
     string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
     string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
 
     add_custom_command (OUTPUT "${OUTPUT_FILE_NAME}"
-                        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} ${SRC} -o ${OUTPUT_FILE_NAME}
+                        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} "${SRC}" -o "${OUTPUT_FILE_NAME}"
                         DEPENDS "${SRC}")
 
-    set (DOC_FILES ${DOC_FILES} "${OUTPUT_FILE_NAME}")
+    list (APPEND DOC_FILES "${OUTPUT_FILE_NAME}")
   endforeach (SRC)
-else (ASCIIDOCTOR_FOUND)
-  file(GLOB MAN_PAGES "${CMAKE_CURRENT_SOURCE_DIR}/*.7")
-  set (DOC_FILES ${DOC_FILES} "${MAN_PAGES}")
-endif (ASCIIDOCTOR_FOUND)
 
-add_custom_target (man7 DEPENDS ${DOC_FILES})
+  add_custom_target (man7 DEPENDS ${DOC_FILES})
+else (ASCIIDOCTOR_FOUND)
+  file (GLOB MAN_PAGES "${CMAKE_CURRENT_SOURCE_DIR}/*.7")
+  set (DOC_FILES ${MAN_PAGES})
+endif (ASCIIDOCTOR_FOUND)
 
 install (FILES ${DOC_FILES} DESTINATION ${TIMEW_MAN7DIR})

--- a/doc/man7/CMakeLists.txt
+++ b/doc/man7/CMakeLists.txt
@@ -1,18 +1,23 @@
 cmake_minimum_required (VERSION 3.10)
 
-file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.7.adoc")
-set (DOC_FILES)
+if (ASCIIDOCTOR_FOUND)
+  file (GLOB DOC_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.7.adoc")
+  set (DOC_FILES)
 
-foreach (SRC ${DOC_SOURCES})
-  string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
-  string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
+  foreach (SRC ${DOC_SOURCES})
+    string (REPLACE ".adoc" "" OUTPUT_FILE_NAME "${SRC}")
+    string (REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" OUTPUT_FILE_NAME "${OUTPUT_FILE_NAME}")
 
-  add_custom_command (OUTPUT "${OUTPUT_FILE_NAME}"
-                      COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} ${SRC} -o ${OUTPUT_FILE_NAME}
-                      DEPENDS "${SRC}")
+    add_custom_command (OUTPUT "${OUTPUT_FILE_NAME}"
+                        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage ${ASCIIDOCTOR_OPTIONS} ${SRC} -o ${OUTPUT_FILE_NAME}
+                        DEPENDS "${SRC}")
 
-  set (DOC_FILES ${DOC_FILES} "${OUTPUT_FILE_NAME}")
-endforeach (SRC)
+    set (DOC_FILES ${DOC_FILES} "${OUTPUT_FILE_NAME}")
+  endforeach (SRC)
+else (ASCIIDOCTOR_FOUND)
+  file(GLOB MAN_PAGES "${CMAKE_CURRENT_SOURCE_DIR}/*.7")
+  set (DOC_FILES ${DOC_FILES} "${MAN_PAGES}")
+endif (ASCIIDOCTOR_FOUND)
 
 add_custom_target (man7 DEPENDS ${DOC_FILES})
 


### PR DESCRIPTION
The generated man pages are already present in the tar ball.
Simply install them then, if Asciidoctor is not present.