### PR TITLE
id filtering for charts and reports

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+- #669    id filtering for charts and reports
 - #660    Fix man page section numbers and reference formatting
 
 ------ current release ---------------------------

--- a/doc/man1/timew-chart.1.adoc
+++ b/doc/man1/timew-chart.1.adoc
@@ -103,11 +103,13 @@ This can be used to see the exclusions.
 The ':ids' hint causes the intervals to be displayed with their ids
 
 == EXAMPLES
-Charts accept date ranges and tags for filtering, or shortcut hints:
+Charts accept date ranges and/or tags, or ids for filtering:
 
     $ timew month 1st - today
     $ timew week FOO BAR
-    $ timew day :week
+    $ timew day @3 @4
+
+See **timew-ranges**(7) and **timew-hints**(7) on the different ways to provide date ranges.
 
 == SEE ALSO
 **timew-summary**(1),

--- a/doc/man1/timew-report.1.adoc
+++ b/doc/man1/timew-report.1.adoc
@@ -6,6 +6,7 @@ timew-report - run an extension report
 == SYNOPSIS
 [verse]
 *timew* [*report*] _<report>_ [_<range>_] [_<tag>_**...**]
+*timew* [*report*] _<report>_ _<id>_**...**
 
 == DESCRIPTION
 Runs an extension report, and supports filtering data.
@@ -19,6 +20,8 @@ This does however assume there is a 'foo' extension installed.
 The return code is the return code of the extension.
 If the extension produces no output and a non-zero rc, then 255 is returned.
 
+Filtering is either possible by range and/or tags, or by ids.
+
 == CONFIGURATION
 
 **reports.range**::
@@ -30,3 +33,4 @@ Defaults to `all`
 Set the date range for report _name_, used if no _range_ is given on the command line.
 Here, _name_ is the name of the report executable without its extension (i.e. a report executable 'foo.py' is referred to by 'foo').
 The value has to correspond to a range hint, see **timew-hints**(7).
+Defaults to the value of **reports.range**.

--- a/src/commands/CmdChart.cpp
+++ b/src/commands/CmdChart.cpp
@@ -28,6 +28,7 @@
 #include <ChartConfig.h>
 #include <Duration.h>
 #include <IntervalFilterAllInRange.h>
+#include <IntervalFilterAllWithIds.h>
 #include <IntervalFilterAllWithTags.h>
 #include <IntervalFilterAndGroup.h>
 #include <Range.h>
@@ -82,16 +83,57 @@ int renderChart (
   Range default_range = {};
   expandIntervalHint (":" + report_hint, default_range);
 
-  auto range = cli.getRange (default_range);
+  auto ids = cli.getIds ();
   auto tags = cli.getTags ();
 
-  // Load the data.
-  IntervalFilterAndGroup filtering ({
-    std::make_shared <IntervalFilterAllInRange> (range),
-    std::make_shared <IntervalFilterAllWithTags> (tags)
-  });
+  if (! ids.empty () && ! tags.empty ())
+  {
+    throw std::string ("You cannot filter intervals by both, ids and tags.");
+  }
 
-  auto tracked = getTracked (database, rules, filtering);
+  Range range;
+
+  std::vector <Interval> tracked;
+
+  if (! ids.empty ())
+  {
+    auto filtering = IntervalFilterAllWithIds (ids);
+    tracked = getTracked (database, rules, filtering);
+
+    if (tracked.size () != ids.size ())
+    {
+      for (auto& id: ids)
+      {
+        bool found = false;
+
+        for (auto& interval: tracked)
+        {
+          if (interval.id == id)
+          {
+            found = true;
+            break;
+          }
+        }
+        if (! found)
+        {
+          throw format ("ID '@{1}' does not correspond to any tracking.", id);
+        }
+      }
+    }
+
+    range = cli.getRange (default_range);
+  }
+  else
+  {
+    range = cli.getRange (default_range);
+
+    IntervalFilterAndGroup filtering ({
+      std::make_shared <IntervalFilterAllInRange> (range),
+      std::make_shared <IntervalFilterAllWithTags> (tags)
+    });
+
+    tracked = getTracked (database, rules, filtering);
+  }
 
   if (tracked.empty ())
   {

--- a/src/commands/CmdExport.cpp
+++ b/src/commands/CmdExport.cpp
@@ -29,6 +29,7 @@
 #include <IntervalFilterAllWithTags.h>
 #include <IntervalFilterAndGroup.h>
 #include <commands.h>
+#include <format.h>
 #include <iostream>
 #include <timew.h>
 
@@ -39,33 +40,52 @@ int CmdExport (
   Database& database)
 {
   auto ids = cli.getIds ();
-  auto range = cli.getRange ();
   auto tags = cli.getTags ();
 
-  std::shared_ptr <IntervalFilter> filtering;
+  if (! ids.empty () && ! tags.empty ())
+  {
+    throw std::string ("You cannot specify both id and tags/range to export intervals.");
+  }
+
+  std::vector <Interval> intervals;
 
   if (! ids.empty ())
   {
-    if (! range.is_empty ())
-    {
-      throw std::string ("You cannot specify both id and tags/range to export intervals.");
-    }
+    auto filtering = IntervalFilterAllWithIds (ids);
+    intervals = getTracked (database, rules, filtering);
 
-    filtering = std::make_shared <IntervalFilterAllWithIds> (ids);
+    if (intervals.size () != ids.size ())
+    {
+      for (auto& id: ids)
+      {
+        bool found = false;
+
+        for (auto& interval: intervals)
+        {
+          if (interval.id == id)
+          {
+            found = true;
+            break;
+          }
+        }
+        if (! found)
+        {
+          throw format ("ID '@{1}' does not correspond to any tracking.", id);
+        }
+      }
+    }
   }
   else
   {
-    filtering = std::make_shared <IntervalFilterAndGroup> (
-      std::vector <std::shared_ptr <IntervalFilter>> (
-        {
-          std::make_shared <IntervalFilterAllInRange> (range),
-          std::make_shared <IntervalFilterAllWithTags> (tags),
-        }
-      )
-    );
-  }
+    auto range = cli.getRange ();
 
-  auto intervals = getTracked (database, rules, *filtering);
+    IntervalFilterAndGroup filtering ({
+      std::make_shared <IntervalFilterAllInRange> (range),
+      std::make_shared <IntervalFilterAllWithTags> (tags)
+    });
+
+    intervals = getTracked (database, rules, filtering);
+  }
 
   std::cout << jsonFromIntervals (intervals);
 

--- a/src/commands/CmdReport.cpp
+++ b/src/commands/CmdReport.cpp
@@ -26,6 +26,7 @@
 
 #include <FS.h>
 #include <IntervalFilterAllInRange.h>
+#include <IntervalFilterAllWithIds.h>
 #include <IntervalFilterAllWithTags.h>
 #include <IntervalFilterAndGroup.h>
 #include <cmake.h>
@@ -133,16 +134,57 @@ int CmdReport (
   Range default_range = {};
   expandIntervalHint (":" + report_hint, default_range);
 
-  // Create a filter, and if empty, choose the current week.
+  auto ids = cli.getIds ();
   auto tags = cli.getTags ();
-  auto range = cli.getRange (default_range);
 
-  IntervalFilterAndGroup filtering ({
-    std::make_shared <IntervalFilterAllInRange> (range),
-    std::make_shared <IntervalFilterAllWithTags> (tags)
-  });
+  if (! ids.empty () && ! tags.empty ())
+  {
+    throw std::string ("You cannot filter intervals by both, ids and tags.");
+  }
 
-  auto tracked = getTracked (database, rules, filtering);
+  Range range;
+
+  std::vector <Interval> tracked;
+
+  if (! ids.empty ())
+  {
+    auto filtering = IntervalFilterAllWithIds (ids);
+    tracked = getTracked (database, rules, filtering);
+
+    if (tracked.size () != ids.size ())
+    {
+      for (auto& id: ids)
+      {
+        bool found = false;
+
+        for (auto& interval: tracked)
+        {
+          if (interval.id == id)
+          {
+            found = true;
+            break;
+          }
+        }
+        if (! found)
+        {
+          throw format ("ID '@{1}' does not correspond to any tracking.", id);
+        }
+      }
+    }
+
+    range = Range {tracked.begin ()->end, tracked.end ()->start};
+  }
+  else
+  {
+    range = cli.getRange (default_range);
+
+    IntervalFilterAndGroup filtering ({
+      std::make_shared <IntervalFilterAllInRange> (range),
+      std::make_shared <IntervalFilterAllWithTags> (tags)
+    });
+
+    tracked = getTracked (database, rules, filtering);
+  }
 
   // Compose Header info.
   rules.set ("temp.report.start", range.is_started () ? range.start.toISO () : "");


### PR DESCRIPTION
This PR adds the possibility to filter the input of reports and charts by ids (like for the `summary` command), e.g.
```
$ timew <report> @1 @2
$ timew week @1 @2
```
