### PR TITLE
Prevent the CLI to canonicalize the binary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -129,3 +129,4 @@ Thanks to the following, who submitted detailed bug reports and excellent sugges
   Eugene Morozov
   Stefan Herold
   Sebastian Carlos
+  ftambara

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- #677    Extension names starting with 'timew' cause problems
+          (thanks to ftambara)
 - #661    Make display of ids and annotations the default in summary report for new users
 - #669    id filtering for charts and reports
 - #660    Fix man page section numbers and reference formatting

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -460,6 +460,12 @@ void CLI::canonicalizeNames ()
 
   for (auto& a : _args)
   {
+    // Do not canonicalize the BINARY
+    if (a.hasTag ("BINARY"))
+    {
+      continue;
+    }
+
     auto raw = a.attribute ("raw");
     std::string canonical = raw;
 


### PR DESCRIPTION
If there is an extension that starts with the same string as the binary, the binary gets canonicalized and also marked as an extension. This in turn prohibits the detection of any other Timewarrior command such that e.g. the command 'summary' in 'timew summary' is treated as an external report, which is not present and thus makes the call fail.

Also, it is not necessary to canonicalize the binary: the first argument on the command line is not used any further when executing the command line.

Closes #677