### PR TITLE
fixed-bash-completion-for-tags

### DIFF
--- a/completion/timew-completion.bash
+++ b/completion/timew-completion.bash
@@ -116,7 +116,7 @@ function __complete_tag()
   declare -a completions
   while read -r line ; do
     completions+=( "${line}" )
-  done < <( compgen -W "$(printf '%q ' "${wordlist[@]}")" -- "${cur}" 2>/dev/null )
+  done < <( compgen -W ${wordlist[@]} -- "${cur}" 2>/dev/null )
 
   for completion in "${completions[@]}" ; do
     COMPREPLY+=( "$(printf "%q" "${completion}")" )


### PR DESCRIPTION
Fixed tag completion by removing unnecessary quoting and printf in compgen call.

Previously, the script passed quoted entries like 'tagname' into compgen -W, preventing proper prefix-based matching (e.g., typing tag_n wouldn't match tag_name1 unless it was the first tag in the list). In that case, Bash would complete to the entire wordlist (tag_name1\ tag_name2\ tag_name3 ...) instead of individual matches.

This was due to the use of printf '%q' and surrounding double quotes, which caused Bash to treat the entire list as a single word.

Replaced with an unquoted ${wordlist[*]} expansion. This restores expected behavior where tab completion suggests tags based on the current prefix.