### PR TITLE
Expose data location through DOM

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -297,6 +297,13 @@ std::string Database::getLatestEntry ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+std::string Database::getLocation ()
+{
+  auto datapath = Path (_location);
+  return datapath;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 void Database::addInterval (const Interval& interval, bool verbose)
 {
   assert ((interval.end == 0) || (interval.start <= interval.end));

--- a/src/Database.h
+++ b/src/Database.h
@@ -100,6 +100,7 @@ public:
   std::set <std::string> tags () const;
 
   std::string getLatestEntry ();
+  std::string getLocation ();
 
   void addInterval (const Interval&, bool verbose);
   void deleteInterval (const Interval&);

--- a/src/dom.cpp
+++ b/src/dom.cpp
@@ -266,6 +266,16 @@ bool domGet (
         return true;
       }
     }
+
+    // dom.data.<...>
+    else if (pig.skipLiteral ("data."))
+    {
+      if (pig.skipLiteral ("location"))
+	{
+	  value = database.getLocation ();
+	  return true;
+	}
+    }
   }
 
   return false;

--- a/test/dom.t
+++ b/test/dom.t
@@ -28,6 +28,7 @@
 
 import os
 import sys
+from pathlib import Path
 import unittest
 
 from datetime import datetime, timezone, timedelta
@@ -153,6 +154,12 @@ class TestDOM(TestCase):
         code, out, err = self.t("get dom.tracked.count")
         self.assertEqual('0\n', out)
 
+    def test_dom_data_location(self):
+        """Test 'dom.data.location'"""
+        code, out, err = self.t("get dom.data.location")
+        datadir = Path(self.t.datadir) / 'data'
+        returned_data_location = out.strip()  # strip new line char
+        self.assertEqual(str(datadir), returned_data_location)
 
 class TestDOMTracked(TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR introduces a new `timew get` target for `dom.data.location` which returns the database path. Closes #692.