### PR TITLE
Add DOM references to query all tags

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@
           (thanks to ftambara)
 - #678    Document report hints with the respective commands
 - #694    Improve documentation on DOM references
+- #696    Add DOM references to query all tags
+          (thanks to Ian Kenney)
 
 ------ current release ---------------------------
 

--- a/doc/man1/timew-get.1.adoc
+++ b/doc/man1/timew-get.1.adoc
@@ -16,7 +16,7 @@ All DOM references start with `dom`, there are 4 subreferences that can be acces
 
 - `dom.tracked`, all intervals
 - `dom.active`, active time tracking
-- `dom.tag`, all tags
+- `dom.tags`, all tags
 - `dom.rc`, configuration settings
 
 See **timew-config**(7) for more details on those.

--- a/doc/man7/timew-dom.7.adoc
+++ b/doc/man7/timew-dom.7.adoc
@@ -10,48 +10,53 @@ All DOM references start with `dom`, there are 4 subreferences that can be acces
 
 - `dom.tracked`, all intervals
 - `dom.active`, active time tracking
-- `dom.tag`, all tags
+- `dom.tags`, all tags
 - `dom.rc`, configuration settings
 
 All intervals::
 `dom.tracked` is a reference to all intervals of the database query result.
 When using this reference, filtering by range and tags can be applied.
 +
-  dom.tracked.count         Count of all intervals in the query result
-  dom.tracked.ids           Ids of all intervals in the query result
-  dom.tracked.tags          Tags of all intervals in the query result
+  dom.tracked.count           Count of all intervals in the query result
+  dom.tracked.ids             Ids of all intervals in the query result
+  dom.tracked.tags            Tags of all intervals in the query result
+  dom.tracked.tags.count      Count of all tags in the query result
+  dom.tracked.tags.<n>        N-th Tag of all tags in the query result
 +
 `dom.tracked.<n>` is a reference to the n-th interval of the database query result.
 Depending on the filtering applied, the n-th interval is not necessarily the one with ID `@n`!
 +
-  dom.tracked.<n>.tag.count Count of tags of the n-th interval
-  dom.tracked.<n>.tag.<m>   N-th interval, m-th tag
-  dom.tracked.<n>.start     N-th interval, start time (ISO Extended date)
-  dom.tracked.<n>.end       N-th interval, end time (ISO Extended date, blank if open)
-  dom.tracked.<n>.duration  N-th interval, duration (ISO Duration)
-  dom.tracked.<n>.json      N-th interval, as JSON
+  dom.tracked.<n>.tags        All tags of the n-th interval
+  dom.tracked.<n>.tags.count  Count of tags of the n-th interval
+  dom.tracked.<n>.tags.<m>    N-th interval, m-th tag
+  dom.tracked.<n>.start       N-th interval, start time (ISO Extended date)
+  dom.tracked.<n>.end         N-th interval, end time (ISO Extended date, blank if open)
+  dom.tracked.<n>.duration    N-th interval, duration (ISO Duration)
+  dom.tracked.<n>.json        N-th interval, as JSON
 
 Active time tracking::
 `dom.active` is a reference to the latest interval in active time tracking.
 It is invalid when no time is tracked.
 +
-  dom.active                '1' if there is active tracking, otherwise '0'
-  dom.active.tag.count      Count of tags
-  dom.active.tag.<n>        N-th tag
-  dom.active.start          Start timestamp (ISO Extended date)
-  dom.active.duration       Elapsed (ISO Period)
-  dom.active.json           Interval as JSON
+  dom.active                  '1' if there is active tracking, otherwise '0'
+  dom.active.tags             All tags of the active tracking
+  dom.active.tags.count       Count of tags
+  dom.active.tags.<n>         N-th tag
+  dom.active.start            Start timestamp (ISO Extended date)
+  dom.active.duration         Elapsed (ISO Period)
+  dom.active.json             Interval as JSON
 
 All tags::
-`dom.tag` is a reference to all tags in the database.
+`dom.tags` is a reference to all tags in the database.
 +
-  dom.tag.count             Count of all tags
-  dom.tag.1                 N-th tag
+  dom.tags                    All tags
+  dom.tags.count              Count of all tags
+  dom.tags.1                  N-th tag
 +
-Without filtering applied, `dom.tracked.tags` refers to the same set of tags as `dom.tag`.
+Without filtering applied, `dom.tracked.tags` refers to the same set of tags as `dom.tags`.
 
 Configuration settings::
 `dom.rc` is a reference to all Timewarrior configuration settings.
 As there are no restrictions for the configuration keys, all those references are valid by design.
 +
-  dom.rc.<name>             Configuration setting <name>
+  dom.rc.<name>              Configuration setting <name>

--- a/src/commands/CmdGet.cpp
+++ b/src/commands/CmdGet.cpp
@@ -31,7 +31,7 @@
 #include <timew.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-// Іdentify DOM references in cli, provide space-separated results.
+// Identify DOM references in CLI, provide space-separated results.
 int CmdGet (
   CLI& cli,
   Rules& rules,

--- a/src/dom.cpp
+++ b/src/dom.cpp
@@ -36,6 +36,38 @@
 #include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
+// Helper function to show tag count
+static bool showTagCount (std::string& value, const std::set<std::string>& tags)
+{
+  value = format ("{1}", tags.size ());
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper function to show tag by index
+static bool showTagByIndex (std::string& value, const std::set<std::string>& tags, const int index)
+{
+  if (1 <= index && index <= static_cast <int> (tags.size ()))
+  {
+    auto it = tags.begin ();
+    std::advance (it, index - 1);
+    value = format ("{1}", *it);
+    return true;
+  }
+  return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper function to show all tags
+static bool showAllTags (std::string& value, const std::set<std::string>& tags)
+{
+  std::stringstream s;
+  s << joinQuotedIfNeeded ( " ", tags );
+  value = s.str ();
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 bool domGet (
   Database& database,
   Interval& filter,
@@ -46,7 +78,7 @@ bool domGet (
   Pig pig (reference);
   if (pig.skipLiteral ("dom."))
   {
-    // dom.active
+    // dom.active[.<...>]
     if (pig.skipLiteral ("active"))
     {
       IntervalFilterFirstOf filtering {std::make_shared <IntervalFilterAllInRange> (Range {})};
@@ -64,53 +96,74 @@ bool domGet (
         return false;
       }
 
-      auto latest = intervals.at (0);
+      const auto& latest = intervals.at (0);
+
+      if (!latest.is_open())
+      {
+        return false;
+      }
 
       // dom.active.start
-      if (pig.skipLiteral (".start") &&
-          latest.is_open ())
+      if (pig.skipLiteral (".start"))
       {
         value = latest.start.toISOLocalExtended ();
         return true;
       }
 
       // dom.active.duration
-      if (pig.skipLiteral (".duration") &&
-          latest.is_open ())
+      if (pig.skipLiteral (".duration"))
       {
         value = Duration (latest.total ()).formatISO ();
         return true;
       }
 
-      // dom.active.tag.count
-      if (pig.skipLiteral (".tag.count") &&
-          latest.is_open ())
-      {
-        value = format ("{1}", latest.tags ().size ());
-        return true;
-      }
-
       // dom.active.json
-      if (pig.skipLiteral (".json") &&
-          latest.is_open ())
+      if (pig.skipLiteral (".json"))
       {
         value = latest.json ();
         return true;
       }
 
-      // dom.active.tag.<N>
-      int n;
-      if (pig.skipLiteral (".tag.") &&
-          pig.getDigits (n))
+      // dom.active.tag.<...>
+      if (pig.skipLiteral (".tag."))
       {
-        if (1 <= n && n <= static_cast <int> (latest.tags ().size ()))
-        {
-          std::vector <std::string> tags;
-          for (auto& tag : latest.tags ())
-            tags.push_back (tag);
+        warn ("DOM reference '.tag.' is deprecated and will be removed in a future version of Timewarrior!\nUse reference '.tags.' instead.");
 
-          value = format ("{1}", tags[n - 1]);
-          return true;
+        // dom.active.tag.count
+        if (pig.skipLiteral ("count"))
+        {
+          return showTagCount (value, latest.tags ());
+        }
+
+        // dom.active.tag.<N>
+        if (int n; pig.getDigits (n))
+        {
+          return showTagByIndex (value, latest.tags (), n);
+        }
+      }
+
+      // dom.active.tags[.<...>]
+      if (pig.skipLiteral (".tags"))
+      {
+        // dom.active.tags
+        if (pig.eos ()) {
+          return showAllTags (value, latest.tags());
+        }
+
+        // dom.active.tags.<...>
+        if (pig.skipLiteral ("."))
+        {
+          // dom.active.tags.count
+          if (pig.skipLiteral ("count"))
+          {
+            return showTagCount (value, latest.tags ());
+          }
+
+          // dom.active.tags.<N>
+          if (int n; pig.getDigits (n))
+          {
+            return showTagByIndex (value, latest.tags (), n);
+          }
         }
       }
     }
@@ -126,7 +179,7 @@ bool domGet (
       auto tracked = getTracked (database, rules, filtering);
       int count = static_cast <int> (tracked.size ());
 
-      // dom.tracked.tags
+      // dom.tracked.tags[.<...>]
       if (pig.skipLiteral ("tags"))
       {
         std::set <std::string> tags;
@@ -138,12 +191,27 @@ bool domGet (
           }
         }
 
-        std::stringstream s;
+        // dom.tracked.tags
+        if (pig.eos ())
+        {
+          return showAllTags (value, tags);
+        }
 
-        s << joinQuotedIfNeeded ( " ", tags );
+        // dom.tracked.tags.<...>
+        if (pig.skipLiteral ("."))
+        {
+          // dom.tracked.tags.count
+          if (pig.skipLiteral ("count"))
+          {
+            return showTagCount (value, tags);
+          }
 
-        value = s.str ();
-        return true;
+          // dom.tracked.tags.<M>
+          if (int m; pig.getDigits (m))
+          {
+            return showTagByIndex (value, tags, m);
+          }
+        }
       }
 
       // dom.tracked.ids
@@ -165,19 +233,11 @@ bool domGet (
         return true;
       }
 
-      int n;
       // dom.tracked.<N>.<...>
-      if (pig.getDigits (n) &&
+      if (int n; pig.getDigits (n) &&
           n <= count        &&
           pig.skipLiteral ("."))
       {
-        // dom.tracked.<N>.tag.count
-        if (pig.skipLiteral ("tag.count"))
-        {
-          value = format ("{1}", tracked[count - n].tags ().size ());
-          return true;
-        }
-
         // dom.tracked.<N>.start
         if (pig.skipLiteral ("start"))
         {
@@ -209,19 +269,47 @@ bool domGet (
           return true;
         }
 
-        int m;
-        // dom.tracked.<N>.tag.<M>
-        if (pig.skipLiteral ("tag.") &&
-            pig.getDigits (m))
+        // dom.tracked.<N>.tag.<...>
+        if (pig.skipLiteral ("tag."))
         {
-          std::vector <std::string> tags;
-          for (auto& tag : tracked[count - n].tags ())
-            tags.push_back (tag);
+          warn ("DOM reference '.tag.' is deprecated and will be removed in a future version of Timewarrior!\nUse reference '.tags.' instead.");
 
-          if (m <= static_cast <int> (tags.size ()))
+          // dom.tracked.<N>.tag.count
+          if (pig.skipLiteral ("count"))
           {
-            value = format ("{1}", tags[m - 1]);
-            return true;
+            return showTagCount (value, tracked[count - n].tags ());
+          }
+
+          // dom.tracked.<N>.tag.<M>
+          if (int m; pig.getDigits (m))
+          {
+            return showTagByIndex (value, tracked[count - n].tags (), m);
+          }
+        }
+
+        // dom.tracked.<N>.tags[.<...>]
+        if (pig.skipLiteral ("tags"))
+        {
+          // dom.tracked.<N>.tags
+          if (pig.eos ())
+          {
+            return showAllTags (value, tracked[count - n].tags ());
+          }
+
+          // dom.tracked.<N>.tags.<...>
+          if (pig.skipLiteral ("."))
+          {
+            // dom.tracked.<N>.tags.count
+            if (pig.skipLiteral ("count"))
+            {
+              return showTagCount (value, tracked[count - n].tags ());
+            }
+
+            // dom.tracked.<N>.tags.<M>
+            if (int m; pig.getDigits (m))
+            {
+              return showTagByIndex (value, tracked[count - n].tags (), m);
+            }
           }
         }
       }
@@ -230,29 +318,46 @@ bool domGet (
     // dom.tag.<...>
     else if (pig.skipLiteral ("tag."))
     {
+      warn ( "DOM reference '.tag.' is deprecated and will be removed in a future version of Timewarrior!\nUse reference '.tags.' instead.");
+
       // get unique, ordered list of tags.
       std::set <std::string> tags = database.tags ();
 
       // dom.tag.count
       if (pig.skipLiteral ("count"))
       {
-        value = format ("{1}", tags.size ());
-        return true;
+        return showTagCount (value, tags);
       }
 
-      int n;
       // dom.tag.<N>
-      if (pig.getDigits (n))
+      if (int n; pig.getDigits (n))
       {
-        if (n <= static_cast <int> (tags.size ()))
-        {
-          std::vector <std::string> all;
-          for (auto& tag : tags)
-            all.push_back (tag);
+        return showTagByIndex (value, tags, n);
+      }
+    }
 
-          value = format ("{1}", all[n - 1]);
-          return true;
-        }
+    // dom.tags[.<...>]
+    else if (pig.skipLiteral ("tags"))
+    {
+      // get unique, ordered list of tags.
+      std::set <std::string> tags = database.tags ();
+
+      // dom.tags
+      if (pig.eos ())
+      {
+        return showAllTags (value, tags);
+      }
+
+      // dom.tags.count
+      if (pig.skipLiteral (".count"))
+      {
+        return showTagCount (value, tags);
+      }
+
+      // dom.tags.<N>
+      if (int n; pig.skipLiteral(".") && pig.getDigits (n))
+      {
+        return showTagByIndex (value, tags, n);
       }
     }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -66,3 +66,16 @@ void debug (const std::string& msg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+void warn (const std::string& msg)
+{
+  const auto warnColor = Color(Color::yellow);
+
+  std::stringstream sstr (msg);
+  std::string line;
+  bool first = true;
+  while (std::getline (sstr, line, '\n'))
+  {
+    std::cerr << warnColor.colorize(first ? "WARNING: " : "         ") << warnColor.colorize(line) << "\n";
+    first = false;
+  }
+}

--- a/src/timew.h
+++ b/src/timew.h
@@ -89,6 +89,7 @@ void enableDebugMode (bool);
 void setDebugIndicator (const std::string&);
 void setDebugColor (const Color&);
 void debug (const std::string&);
+void warn (const std::string&);
 
 // util.cpp
 std::string escape (const std::string&, int);

--- a/test/dom.t
+++ b/test/dom.t
@@ -70,6 +70,28 @@ class TestDOM(TestCase):
         code, out, err = self.t("get dom.tag.2")
         self.assertEqual('two\n', out)
 
+    def test_dom_tags_count_zero(self):
+        """Test 'dom.tags.count' with zero tags"""
+        code, out, err = self.t("get dom.tags.count")
+        self.assertEqual('0\n', out)
+
+    def test_dom_tags_count_two(self):
+        """Test 'dom.tags.count' with two tags"""
+        self.t("start one two")
+        code, out, err = self.t("get dom.tags.count")
+        self.assertEqual('2\n', out)
+
+    def test_dom_tags_N_none(self):
+        """Test 'dom.tags.N' with no data"""
+        code, out, err = self.t.runError("get dom.tags.1")
+        self.assertIn("DOM reference 'dom.tags.1' is not valid.", err)
+
+    def test_dom_tags_N_two(self):
+        """Test 'dom.tags.N' with two tags"""
+        self.t("start one two")
+        code, out, err = self.t("get dom.tags.2")
+        self.assertEqual('two\n', out)
+
     def test_dom_active_inactive(self):
         """Test 'dom.active' without an active interval"""
         code, out, err = self.t("get dom.active")
@@ -148,6 +170,87 @@ class TestDOM(TestCase):
         code, out, err = self.t("get dom.active.json")
         self.assertRegex(out, r'{"id":1,"start":"\d{8}T\d{6}Z","tags":\["foo"\]}')
 
+    def test_dom_active_tags_inactive(self):
+        """Test 'dom.active.tags' without an active interval"""
+        code, out, err = self.t.runError("get dom.active.tags")
+        self.assertIn("DOM reference 'dom.active.tags' is not valid.", err)
+
+    def test_dom_active_tags_zero(self):
+        """Test 'dom.active.tags' with zero tags"""
+        self.t("start")
+        code, out, err = self.t("get dom.active.tags")
+        self.assertEqual('\n', out)
+
+    def test_dom_active_tags_one(self):
+        """Test 'dom.active.tags' with one tag"""
+        self.t("start foo")
+        code, out, err = self.t("get dom.active.tags")
+        self.assertEqual('foo\n', out)
+
+    def test_dom_active_tags_two(self):
+        """Test 'dom.active.tags' with two tags"""
+        self.t("start foo bar")
+        code, out, err = self.t("get dom.active.tags")
+        self.assertEqual('bar foo\n', out)
+
+    def test_dom_active_tags_with_quotes(self):
+        """Test 'dom.active.tags' with a tag containing spaces"""
+        self.t("start \"with spaces\" bar")
+        code, out, err = self.t("get dom.active.tags")
+        self.assertEqual('bar \"with spaces\"\n', out)
+
+    def test_dom_active_tags_N_inactive(self):
+        """Test 'dom.active.tags.N' without an active interval"""
+        code, out, err = self.t.runError("get dom.active.tags.1")
+        self.assertIn("DOM reference 'dom.active.tags.1' is not valid.", err)
+
+    def test_dom_active_tags_N_zero(self):
+        """Test 'dom.active.tags.N' with zero tags"""
+        self.t("start")
+        code, out, err = self.t.runError("get dom.active.tags.1")
+        self.assertIn("DOM reference 'dom.active.tags.1' is not valid.", err)
+
+    def test_dom_active_tags_N_one(self):
+        """Test 'dom.active.tags.N' with one tag"""
+        self.t("start foo")
+        code, out, err = self.t("get dom.active.tags.1")
+        self.assertEqual('foo\n', out)
+
+    def test_dom_active_tags_N_two(self):
+        """Test 'dom.active.tags.N' with two tags"""
+        self.t("start foo bar")
+        code, out, err = self.t("get dom.active.tags.2")
+        self.assertEqual('foo\n', out)
+
+    def test_dom_active_tags_N_invalid(self):
+        """Test 'dom.active.tags.N' with invalid index"""
+        self.t("start foo")
+        code, out, err = self.t.runError("get dom.active.tags.2")
+        self.assertIn("DOM reference 'dom.active.tags.2' is not valid.", err)
+
+    def test_dom_active_tags_count_inactive(self):
+        """Test 'dom.active.tags.count' without an active interval"""
+        code, out, err = self.t.runError("get dom.active.tags.count")
+        self.assertIn("DOM reference 'dom.active.tags.count' is not valid.", err)
+
+    def test_dom_active_tags_count_zero(self):
+        """Test 'dom.active.tags.count' with zero tags"""
+        self.t("start")
+        code, out, err = self.t("get dom.active.tags.count")
+        self.assertEqual('0\n', out)
+
+    def test_dom_active_tags_count_one(self):
+        """Test 'dom.active.tags.count' with one tag"""
+        self.t("start foo")
+        code, out, err = self.t("get dom.active.tags.count")
+        self.assertEqual('1\n', out)
+
+    def test_dom_active_tags_count_two(self):
+        """Test 'dom.active.tags.count' with two tags"""
+        self.t("start foo bar")
+        code, out, err = self.t("get dom.active.tags.count")
+        self.assertEqual('2\n', out)
+
     def test_dom_tracked_count_none(self):
         """Test 'dom.active' without an active interval"""
         code, out, err = self.t("get dom.tracked.count")
@@ -196,6 +299,31 @@ class TestDOMTracked(TestCase):
 
         code, out, err = self.t("get dom.tracked.tags")
         self.assertEqual("bar foo\n", out)
+
+    def test_dom_tracked_tags_count_with_no_tags(self):
+        """Test 'dom.tracked.tags.count' with no tags"""
+        now_utc = datetime.now(timezone.utc)
+        four_hours_before_utc = now_utc - timedelta(hours=4)
+        five_hours_before_utc = now_utc - timedelta(hours=5)
+
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z".format(five_hours_before_utc, four_hours_before_utc))
+
+        code, out, err = self.t("get dom.tracked.tags.count")
+        self.assertEqual("0\n", out)
+
+    def test_dom_tracked_tags_count_with_tags(self):
+        """Test 'dom.tracked.tags.count' with tags"""
+        now_utc = datetime.now(timezone.utc)
+        two_hours_before_utc = now_utc - timedelta(hours=2)
+        three_hours_before_utc = now_utc - timedelta(hours=3)
+        four_hours_before_utc = now_utc - timedelta(hours=4)
+        five_hours_before_utc = now_utc - timedelta(hours=5)
+
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z foo".format(five_hours_before_utc, four_hours_before_utc))
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z bar".format(three_hours_before_utc, two_hours_before_utc))
+
+        code, out, err = self.t("get dom.tracked.tags.count")
+        self.assertEqual("2\n", out)
 
     def test_dom_tracked_tags_with_quoted_tag(self):
         """Test 'dom.tracked.tags' with a tag with quotes"""
@@ -394,6 +522,117 @@ class TestDOMTracked(TestCase):
 
         code, out, err = self.t("get dom.tracked.1.json")
         self.assertRegex(out, r'{"id":1,"start":"\d{8}T\d{6}Z"}')
+
+    def test_dom_tracked_N_tags_none(self):
+        """Test 'dom.tracked.N.tags' with no data"""
+        code, out, err = self.t.runError("get dom.tracked.1.tags")
+        self.assertIn("DOM reference 'dom.tracked.1.tags' is not valid.", err)
+
+    def test_dom_tracked_N_tags_zero(self):
+        """Test 'dom.tracked.N.tags' with zero tags"""
+        self.t("track :yesterday")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags")
+        self.assertEqual('\n', out)
+
+    def test_dom_tracked_N_tags_one(self):
+        """Test 'dom.tracked.N.tags' with one tag"""
+        self.t("track :yesterday foo")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags")
+        self.assertEqual('foo\n', out)
+
+    def test_dom_tracked_N_tags_two(self):
+        """Test 'dom.tracked.N.tags' with two tags"""
+        self.t("track :yesterday one two")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags")
+        self.assertEqual('one two\n', out)
+
+    def test_dom_tracked_N_tags_with_quotes(self):
+        """Test 'dom.tracked.N.tags' with a tag containing spaces"""
+        self.t("track :yesterday \"with spaces\" bar")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags")
+        self.assertEqual('bar \"with spaces\"\n', out)
+
+    def test_dom_tracked_N_tags_active_interval(self):
+        """Test 'dom.tracked.N.tags' with active interval (first in list)"""
+        self.t("track :yesterday one two")
+        self.t("start foo bar")
+
+        code, out, err = self.t("get dom.tracked.1.tags")
+        self.assertEqual('bar foo\n', out)
+
+    def test_dom_tracked_N_tags_M_none(self):
+        """Test 'dom.tracked.N.tags.M' with no data"""
+        code, out, err = self.t.runError("get dom.tracked.1.tags.1")
+        self.assertIn("DOM reference 'dom.tracked.1.tags.1' is not valid.", err)
+
+    def test_dom_tracked_N_tags_M_zero(self):
+        """Test 'dom.tracked.N.tags.M' with zero tags"""
+        self.t("track :yesterday")
+        self.t("start")
+
+        code, out, err = self.t.runError("get dom.tracked.2.tags.1")
+        self.assertIn("DOM reference 'dom.tracked.2.tags.1' is not valid.", err)
+
+    def test_dom_tracked_N_tags_M_one(self):
+        """Test 'dom.tracked.N.tags.M' with one tag"""
+        self.t("track :yesterday foo")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags.1")
+        self.assertEqual('foo\n', out)
+
+    def test_dom_tracked_N_tags_M_two(self):
+        """Test 'dom.tracked.N.tags.M' with two tags"""
+        self.t("track :yesterday one two")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags.2")
+        self.assertEqual('two\n', out)
+
+    def test_dom_tracked_N_tags_M_invalid(self):
+        """Test 'dom.tracked.N.tags.M' with invalid index"""
+        self.t("track :yesterday foo")
+        self.t("start")
+
+        code, out, err = self.t.runError("get dom.tracked.2.tags.2")
+        self.assertIn("DOM reference 'dom.tracked.2.tags.2' is not valid.", err)
+
+    def test_dom_tracked_N_tags_count_none(self):
+        """Test 'dom.tracked.N.tags.count' with no data"""
+        code, out, err = self.t.runError("get dom.tracked.1.tags.count")
+        self.assertIn("DOM reference 'dom.tracked.1.tags.count' is not valid.", err)
+
+    def test_dom_tracked_N_tags_count_zero(self):
+        """Test 'dom.tracked.N.tags.count' with zero tags"""
+        self.t("track :yesterday")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags.count")
+        self.assertEqual('0\n', out)
+
+    def test_dom_tracked_N_tags_count_one(self):
+        """Test 'dom.tracked.N.tags.count' with one tag"""
+        self.t("track :yesterday foo")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags.count")
+        self.assertEqual('1\n', out)
+
+    def test_dom_tracked_N_tags_count_two(self):
+        """Test 'dom.tracked.N.tags.count' with two tags"""
+        self.t("track :yesterday one two")
+        self.t("start")
+
+        code, out, err = self.t("get dom.tracked.2.tags.count")
+        self.assertEqual('2\n', out)
 
 
 class TestDOMRC(TestCase):


### PR DESCRIPTION
This PR adds support for DOM references `dom.active.tags`, `dom.tracked.<n>.tags`, and `dom.tags`, to return the respective tag set. The already present reference `dom.tracked.tags` was extended to also support `dom.tracked.tags.count` and `dom.tracked.tags.<n>`.

As a side effect, the reference nodes `.tag.` were deprecated in favor of `.tags.`:
| deprecated | new |
|--------|--------|
| `-` | `dom.active.tags` |
| `dom.active.tag.count` | `dom.active.tags.count` |
| `dom.active.tag.<n>` | `dom.active.tags.<n>` |
| `-` | `dom.tracked.tags.count` |
| `-` | `dom.tracked.tags.<n>` |
| `-` | `dom.tracked.<m>.tags` |
| `dom.tracked.<m>.tag.count` | `dom.tracked.<m>.tags.count` |
| `dom.tracked.<m>.tag.<n>` | `dom.tracked.<m>.tags.<n>` | 
| `-` | `dom.tags` |
| `dom.tag.count` | `dom.tags.count` |
| `dom.tag.<n>` | `dom.tags.<n>` | 

Calling `timew get` with a `.tag.` reference still works, but a deprecation warning with an urge to switch to `.tags.` is emitted on stderr in this case.

Closes #695 