### PR TITLE
Enable :fill hint for command 'modify'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
 - #694    Improve documentation on DOM references
 - #696    Add DOM references to query all tags
           (thanks to Ian Kenney)
+- #697    Enable :fill hint for command 'modify'
 
 ------ current release ---------------------------
 

--- a/doc/man1/timew-modify.1.adoc
+++ b/doc/man1/timew-modify.1.adoc
@@ -19,6 +19,18 @@ One can add the ':adjust' hint to force an overwrite in this case.
 
 See **timew-summary**(1) on how to retrieve the interval id.
 
+== HINTS
+The 'modify' command accepts the following hints:
+
+**:fill**::
+The ':fill' hint can be used instead of a date or date range to fill the gap between the interval to be modified and its adjacent intervals.
+For subcommands 'start' and 'end', the ':fill' hint will fill the gap between the targeted interval and the next or previous interval respectively.
+For the 'range' subcommand, it will fill gaps on both sides of the modified interval.
+
+**:adjust**::
+The ':adjust' hint can be added to force the modification of the interval, if it overlaps with an existing interval.
+This will overwrite the existing interval.
+
 == EXAMPLES
 *Modify the start date of an interval*::
 +
@@ -42,6 +54,12 @@ Instead of modifying start and end separately, those can be combined into a sing
     $ timew modify range @3 2020-12-28T17:00 - 2020-12-28T18:00
 +
 As in the examples above, the date portion can be omitted, if the date of the interval is today.
+
+*Modify the range of an interval and fill gaps*::
++
+    $ timew modify range @3 :fill
++
+This modifies the interval '@3' and automatically fills any gaps between this interval and its adjacent intervals.
 
 == SEE ALSO
 **timew-lengthen**(1),

--- a/doc/man1/timew-start.1.adoc
+++ b/doc/man1/timew-start.1.adoc
@@ -11,6 +11,13 @@ timew-start - start time tracking
 Begins tracking using the current time with any specified set of tags.
 If a tag contains multiple words, therefore containing spaces, use quotes to surround the whole tag.
 
+== HINTS
+The start command accepts the following hints:
+
+**:fill**::
+The ':fill' hint can be used to create a new interval that starts right after the last closed interval.
+This is useful when you want to start tracking time immediately after finishing a previous task without specifying a start time.
+
 == EXAMPLES
 For example, this command specifies two tags ('weekend' and 'Home & Garden'), the second of which requires quotes.
 

--- a/doc/man1/timew-track.1.adoc
+++ b/doc/man1/timew-track.1.adoc
@@ -11,14 +11,30 @@ timew-track - add intervals to the database
 The track command is used to add tracked time in the past.
 Perhaps you forgot to record time, or are just filling in old entries.
 
-== EXAMPLES
-For example:
+== HINTS
+Apart from range hints (see **timew-hints**(7)), the track command accepts the following hints:
 
+**:fill**::
+The ':fill' hint can be used to create a new interval that fills the gap between two adjacent intervals.
+
+== EXAMPLES
+*Recording a closed interval*::
+
+For example:
++
     $ timew track :yesterday 'Training Course'
     $ timew track 9am - 11am 'Staff Meeting'
-
++
 Note that the track command expects a closed interval (start and end time), when recording.
 If a closed interval is not provided, the 'track' command behaves the same as the 'start' command.
+
+*Filling the gap between two intervals*::
+To fill the gap between two intervals, without having to specify the exact times, one can use the :fill hint.
+When e.g. the first interval ends some time before 10:00 and the second interval starts some time after 11:00, calling
++
+    $ timew track 10:00 - 11:00 :fill 'Coffee Break'
++
+will instruct Timewarrior to expand the interval such that it starts right after the first interval and ends right before the second interval.
 
 == SEE ALSO
 **timew-cancel**(1),

--- a/src/commands/CmdContinue.cpp
+++ b/src/commands/CmdContinue.cpp
@@ -42,6 +42,7 @@ int CmdContinue (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
   const Datetime now {};
 
   auto range = cli.getRange ({now, 0});
@@ -124,7 +125,7 @@ int CmdContinue (
 
   journal.startTransaction ();
 
-  if (validate (cli, rules, database, to_copy))
+  if (autoAdjust (do_adjust, rules, database, to_copy))
   {
     database.addInterval (to_copy, verbose);
     journal.endTransaction ();

--- a/src/commands/CmdFill.cpp
+++ b/src/commands/CmdFill.cpp
@@ -39,6 +39,7 @@ int CmdFill (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   auto ids = cli.getIds ();
 
@@ -66,8 +67,8 @@ int CmdFill (
     Interval to {from};
 
     database.deleteInterval (from);
-    autoFill (rules, database, to);
-    validate (cli, rules, database, to);
+    fillRange (rules, database, to);
+    autoAdjust (do_adjust, rules, database, to);
     std::cout << "# to " << to.dump () << "\n";
     database.addInterval (to, verbose);
 

--- a/src/commands/CmdImport.cpp
+++ b/src/commands/CmdImport.cpp
@@ -101,7 +101,7 @@ std::vector<Interval> import_file (const std::string& file_name)
 }
 
 void import_intervals (
-    const CLI& cli,
+    const bool do_adjust,
     const Rules& rules,
     Database& database,
     Journal& journal,
@@ -112,7 +112,7 @@ void import_intervals (
     for (auto& interval: intervals)
     {
         // Add each interval to the database
-        if (validate (cli, rules, database, interval))
+        if (autoAdjust (do_adjust, rules, database, interval))
         {
             database.addInterval (interval, verbose);
             database.commit ();
@@ -129,13 +129,14 @@ int CmdImport (
     Journal &journal)
 {
     const bool verbose = rules.getBoolean ("verbose");
+    const bool do_adjust = cli.getHint ("adjust", false);
 
     if (const auto fileNames = cli.getWords (); fileNames.empty ())
     {
         const auto content = read_input ();
         auto intervals = parse_content (content);
 
-        import_intervals (cli, rules, database, journal, verbose, intervals);
+        import_intervals (do_adjust, rules, database, journal, verbose, intervals);
 
         if (verbose)
         {
@@ -151,7 +152,7 @@ int CmdImport (
             {
                 auto intervals = import_file (fileName);
 
-                import_intervals (cli, rules, database, journal, verbose, intervals);
+                import_intervals (do_adjust, rules, database, journal, verbose, intervals);
 
                 if (verbose)
                 {

--- a/src/commands/CmdJoin.cpp
+++ b/src/commands/CmdJoin.cpp
@@ -39,6 +39,7 @@ int CmdJoin (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   // Gather IDs and TAGs.
   auto ids = cli.getIds ();
@@ -92,7 +93,7 @@ int CmdJoin (
   database.deleteInterval (first);
   database.deleteInterval (second);
 
-  validate (cli, rules, database, combined);
+  autoAdjust (do_adjust, rules, database, combined);
   database.addInterval (combined, verbose);
 
   journal.endTransaction ();

--- a/src/commands/CmdLengthen.cpp
+++ b/src/commands/CmdLengthen.cpp
@@ -39,6 +39,7 @@ int CmdLengthen (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   auto ids = cli.getIds ();
 
@@ -87,7 +88,7 @@ int CmdLengthen (
     database.deleteInterval (interval);
 
     interval.end += dur.toTime_t ();
-    validate (cli, rules, database, interval);
+    autoAdjust (do_adjust, rules, database, interval);
     database.addInterval (interval, verbose);
 
     if (verbose)

--- a/src/commands/CmdModifyEnd.cpp
+++ b/src/commands/CmdModifyEnd.cpp
@@ -38,6 +38,8 @@ int CmdModifyEnd (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_fill = cli.getHint ("fill", false);
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   auto ids = cli.getIds ();
 
@@ -65,28 +67,37 @@ int CmdModifyEnd (
   }
 
   assert (intervals.size () == 1);
-  if (! range.is_started ())
+  
+  if (! range.is_started () && ! do_fill)
   {
     throw std::string ("No updated time specified. See 'timew help modify'.");
   }
 
-  const Interval interval = intervals.at (0);
+  const Interval& interval = intervals.at (0);
   Interval modified {interval};
   if (interval.is_open ())
   {
     throw format ("Cannot modify end of open interval @{1}.", id);
   }
-  modified.end = range.start;
 
-  if (! modified.is_open () && (modified.start > modified.end))
+  if (! do_fill)
+  {
+    modified.end = range.start;
+  }
+  else
+  {
+    fillRangeEnd (rules, database, modified);
+  }
+
+  if (! modified.is_open () && modified.start > modified.end)
   {
     throw format ("Cannot modify interval @{1} where start is after end.", id);
   }
-  
+
   journal.startTransaction ();
 
   database.deleteInterval (interval);
-  validate (cli, rules, database, modified);
+  autoAdjust (do_adjust, rules, database, modified);
   database.addInterval (modified, verbose);
 
   journal.endTransaction();

--- a/src/commands/CmdModifyRange.cpp
+++ b/src/commands/CmdModifyRange.cpp
@@ -38,6 +38,8 @@ int CmdModifyRange (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_fill = cli.getHint ("fill", false);
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   auto ids = cli.getIds ();
 
@@ -70,25 +72,34 @@ int CmdModifyRange (
   }
 
   assert (intervals.size () == 1);
-  if (! range.is_started ())
+  
+  if (! range.is_started () && ! do_fill)
   {
     throw std::string ("No updated time specified. See 'timew help modify'.");
   }
 
-  const Interval interval = intervals.at (0);
+  const Interval& interval = intervals.at (0);
   Interval modified {interval};
-  modified.start = range.start;
-  modified.end = range.end;
 
-  if (! modified.is_open () && (modified.start > modified.end))
+  if (! do_fill)
+  {
+    modified.start = range.start;
+    modified.end = range.end;
+  }
+  else
+  {
+    fillRange (rules, database, modified);
+  }
+
+  if (! modified.is_open () && modified.start > modified.end)
   {
     throw format ("Cannot modify interval @{1} where start is after end.", id);
   }
-  
+
   journal.startTransaction ();
 
   database.deleteInterval (interval);
-  validate (cli, rules, database, modified);
+  autoAdjust (do_adjust, rules, database, modified);
   database.addInterval (modified, verbose);
 
   journal.endTransaction();

--- a/src/commands/CmdModifyStart.cpp
+++ b/src/commands/CmdModifyStart.cpp
@@ -38,6 +38,8 @@ int CmdModifyStart (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_fill = cli.getHint ("fill", false);
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   auto ids = cli.getIds ();
 
@@ -65,24 +67,33 @@ int CmdModifyStart (
   }
 
   assert (intervals.size () == 1);
-  if (! range.is_started ())
+  
+  if (! range.is_started () && ! do_fill)
   {
     throw std::string ("No updated time specified. See 'timew help modify'.");
   }
 
-  const Interval interval = intervals.at (0);
+  const Interval& interval = intervals.at (0);
   Interval modified {interval};
-  modified.start = range.start;
 
-  if (! modified.is_open () && (modified.start > modified.end))
+  if (! do_fill)
+  {
+    modified.start = range.start;
+  }
+  else
+  {
+    fillRangeStart (rules, database, modified);
+  }
+
+  if (! modified.is_open () && modified.start > modified.end)
   {
     throw format ("Cannot modify interval @{1} where start is after end.", id);
   }
-  
+
   journal.startTransaction ();
 
   database.deleteInterval (interval);
-  validate (cli, rules, database, modified);
+  autoAdjust (do_adjust, rules, database, modified);
   database.addInterval (modified, verbose);
 
   journal.endTransaction();

--- a/src/commands/CmdMove.cpp
+++ b/src/commands/CmdMove.cpp
@@ -39,6 +39,7 @@ int CmdMove (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   // Gather ID and TAGs.
   std::set <int> ids = cli.getIds ();
@@ -126,7 +127,7 @@ int CmdMove (
 
   database.deleteInterval (intervals.at (0));
 
-  validate (cli, rules, database, interval);
+  autoAdjust (do_adjust, rules, database, interval);
   database.addInterval (interval, verbose);
 
   journal.endTransaction ();

--- a/src/commands/CmdResize.cpp
+++ b/src/commands/CmdResize.cpp
@@ -39,6 +39,7 @@ int CmdResize (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   std::set <int> ids = cli.getIds ();
 
@@ -85,7 +86,7 @@ int CmdResize (
     database.deleteInterval (interval);
 
     interval.end = interval.start + dur.toTime_t ();
-    validate (cli, rules, database, interval);
+    autoAdjust (do_adjust, rules, database, interval);
     database.addInterval (interval, verbose);
 
     if (verbose)

--- a/src/commands/CmdShorten.cpp
+++ b/src/commands/CmdShorten.cpp
@@ -39,6 +39,7 @@ int CmdShorten (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   std::set <int> ids = cli.getIds ();
 
@@ -94,7 +95,7 @@ int CmdShorten (
     database.deleteInterval (interval);
 
     interval.end -= dur.toTime_t ();
-    validate (cli, rules, database, interval);
+    autoAdjust (do_adjust, rules, database, interval);
     database.addInterval (interval, verbose);
 
     if (verbose)

--- a/src/commands/CmdSplit.cpp
+++ b/src/commands/CmdSplit.cpp
@@ -39,6 +39,7 @@ int CmdSplit (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   std::set <int> ids = cli.getIds ();
 
@@ -95,10 +96,10 @@ int CmdSplit (
 
     database.deleteInterval (interval);
 
-    validate (cli, rules, database, first);
+    autoAdjust (do_adjust, rules, database, first);
     database.addInterval (first, verbose);
 
-    validate (cli, rules, database, second);
+    autoAdjust (do_adjust, rules, database, second);
     database.addInterval (second, verbose);
 
     if (verbose)

--- a/src/commands/CmdStart.cpp
+++ b/src/commands/CmdStart.cpp
@@ -36,6 +36,8 @@ int CmdStart (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_fill = cli.getHint ("fill", false);
+  const bool do_adjust = cli.getHint ("adjust", false);
   const Datetime now {};
 
   auto range = cli.getRange ({now, 0});
@@ -61,7 +63,12 @@ int CmdStart (
   journal.startTransaction ();
   auto interval = Interval {range, tags};
 
-  if (validate (cli, rules, database, interval))
+  if (do_fill)
+  {
+    fillRangeStart (rules, database, interval);
+  }
+  
+  if (autoAdjust (do_adjust, rules, database, interval))
   {
     database.addInterval (interval, verbose);
     journal.endTransaction ();

--- a/src/commands/CmdStop.cpp
+++ b/src/commands/CmdStop.cpp
@@ -48,6 +48,7 @@ int CmdStop (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_adjust = cli.getHint ("adjust", false);
   const Datetime now {};
 
   // Load the most recent interval.
@@ -105,7 +106,7 @@ int CmdStop (
     modified.end = range.start;
 
     database.deleteInterval (latest);
-    validate (cli, rules, database, modified);
+    autoAdjust (do_adjust, rules, database, modified);
 
     for (auto& interval : flatten (modified, getAllExclusions (rules, modified)))
     {
@@ -125,7 +126,7 @@ int CmdStop (
       next.tag (tag);
     }
 
-    validate (cli, rules, database, next);
+    autoAdjust (do_adjust, rules, database, next);
     database.addInterval (next, verbose);
 
     if (verbose)

--- a/src/commands/CmdTrack.cpp
+++ b/src/commands/CmdTrack.cpp
@@ -36,6 +36,8 @@ int CmdTrack (
   Journal& journal)
 {
   const bool verbose = rules.getBoolean ("verbose");
+  const bool do_fill = cli.getHint ("fill", false);
+  const bool do_adjust = cli.getHint ("adjust", false);
 
   // We expect no ids
   if (! cli.getIds ().empty ())
@@ -60,7 +62,11 @@ int CmdTrack (
   auto filter = Interval {range, tags};
 
   // Validation must occur before flattening.
-  validate (cli, rules, database, filter);
+  if (do_fill)
+  {
+    fillRange (rules, database, filter);
+  }
+  autoAdjust (do_adjust, rules, database, filter);
 
   for (auto& interval : flatten (filter, getAllExclusions (rules, range)))
   {

--- a/src/timew.h
+++ b/src/timew.h
@@ -57,8 +57,10 @@ Interval                getLatestInterval (Database&);
 Range                   getFullDay        (const Datetime&);
 
 // validate.cpp
-void autoFill (const Rules&, Database&, Interval&);
-bool validate (const CLI& cli, const Rules& rules, Database&, Interval&);
+void fillRange (const Rules&, Database&, Interval&);
+void fillRangeStart (const Rules&, Database&, Interval&);
+void fillRangeEnd (const Rules&, Database&, Interval&);
+bool autoAdjust (bool, const Rules&, Database&, Interval&);
 
 // init.cpp
 bool lightweightVersionCheck (int, const char**);

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -30,58 +30,82 @@
 #include <timew.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-// :fill
-//   The :fill hint is used to eliminate gaps on interval modification, and only
-//   a single interval is affected.
+// Fill an interval start to the end of the preceding interval (fill-backward)
 //
-//   Fill works by extending an interval in both directions if possible, to
-//   about either an interval or an exclusion, while being constrained by a
-//   filter range.
-//
-void autoFill (
+void fillRangeStart (
   const Rules& rules,
   Database& database,
   Interval& interval)
 {
+  const bool verbose = rules.getBoolean ("verbose");
   // An empty filter allows scanning beyond interval range.
   auto range_filter = IntervalFilterAllInRange ({0, 0});
 
   // Look backwards from interval.start to a boundary.
-  auto tracked = getTracked (database, rules, range_filter);
+  const auto tracked = getTracked (database, rules, range_filter);
   for (auto earlier = tracked.rbegin (); earlier != tracked.rend (); ++earlier)
   {
-    if (! earlier->is_open () &&
-        earlier->end <= interval.start)
+    if (! earlier->is_open () && earlier->end <= interval.start)
     {
       interval.start = earlier->end;
-        if (rules.getBoolean ("verbose"))
+      if (verbose)
+      {
         std::cout << "Backfilled "
                   << (interval.id ? format ("@{1} ", interval.id) : "")
                   << "to "
                   << interval.start.toISOLocalExtended ()
                   << "\n";
+      }
       break;
     }
   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Fill an interval end to the start of the following interval (fill-forward)
+//
+void fillRangeEnd (
+  const Rules& rules,
+  Database& database,
+  Interval& interval)
+{
+  const bool verbose = rules.getBoolean ("verbose");
+  // An empty filter allows scanning beyond interval range.
+  auto range_filter = IntervalFilterAllInRange ({0, 0});
 
   // If the interval is closed, scan forwards for the next boundary.
   if (! interval.is_open ())
   {
+    const auto tracked = getTracked (database, rules, range_filter);
     for (auto& later : tracked)
     {
       if (interval.end <= later.start)
       {
         interval.end = later.start;
-        if (rules.getBoolean ("verbose"))
+        if (verbose)
+        {
           std::cout << "Filled "
                     << (interval.id ? format ("@{1} ", interval.id) : "")
                     << "to "
                     << interval.end.toISOLocalExtended ()
                     << "\n";
+        }
         break;
       }
     }
   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Fill an interval to the borders of its surrounding intervals
+//
+void fillRange (
+  const Rules& rules,
+  Database& database,
+  Interval& interval)
+{
+  fillRangeStart (rules, database, interval);
+  fillRangeEnd (rules, database, interval);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -91,7 +115,7 @@ void autoFill (
 //   can involve rejection, adjustment of modified interval, or adjustment of
 //   recorded data.
 //
-static bool autoAdjust (
+bool autoAdjust (
   bool adjust,
   const Rules& rules,
   Database& database,
@@ -151,91 +175,73 @@ static bool autoAdjust (
   {
     throw std::string ("You cannot overlap intervals. Correct the start/end time, or specify the :adjust hint.");
   }
-  else
+
+  // implement overwrite resolution, i.e. the new interval overwrites existing intervals
+  for (auto& overlap : overlaps)
   {
-    // implement overwrite resolution, i.e. the new interval overwrites existing intervals
-    for (auto& overlap : overlaps)
+    bool start_within_overlap = interval.startsWithin (overlap);
+    bool end_within_overlap = interval.endsWithin (overlap);
+
+    if (start_within_overlap && !end_within_overlap)
     {
-      bool start_within_overlap = interval.startsWithin (overlap);
-      bool end_within_overlap = interval.endsWithin (overlap);
+      // start date of new interval within old interval
+      Interval modified {overlap};
+      modified.end = interval.start;
 
-      if (start_within_overlap && !end_within_overlap)
+      if (modified.is_empty ())
       {
-        // start date of new interval within old interval
-        Interval modified {overlap};
-        modified.end = interval.start;
-
-        if (modified.is_empty ())
-        {
-          database.deleteInterval (overlap);
-        }
-        else
-        {
-          database.modifyInterval (overlap, modified, verbose);
-        }
-      }
-      else if (! start_within_overlap && end_within_overlap)
-      {
-        // end date of new interval within old interval
-        Interval modified {overlap};
-        modified.start = interval.end;
-
-        if (modified.is_empty ())
-        {
-          database.deleteInterval (overlap);
-        }
-        else
-        {
-          database.modifyInterval (overlap, modified, verbose);
-        }
-      }
-      else if (! start_within_overlap && ! end_within_overlap)
-      {
-        // new interval encloses old interval
         database.deleteInterval (overlap);
       }
       else
       {
-        // new interval enclosed by old interval
-        Interval split2 {overlap};
-        Interval split1 {overlap};
+        database.modifyInterval (overlap, modified, verbose);
+      }
+    }
+    else if (!start_within_overlap && end_within_overlap)
+    {
+      // end date of new interval within old interval
+      Interval modified {overlap};
+      modified.start = interval.end;
 
-        split1.end = interval.start;
-        split2.start = interval.end;
+      if (modified.is_empty ())
+      {
+        database.deleteInterval (overlap);
+      }
+      else
+      {
+        database.modifyInterval (overlap, modified, verbose);
+      }
+    }
+    else if (! start_within_overlap && ! end_within_overlap)
+    {
+      // new interval encloses old interval
+      database.deleteInterval (overlap);
+    }
+    else
+    {
+      // new interval enclosed by old interval
+      Interval split2 {overlap};
+      Interval split1 {overlap};
 
-        if (split1.is_empty ())
-        {
-          database.deleteInterval (overlap);
-        }
-        else
-        {
-          database.modifyInterval (overlap, split1, verbose);
-        }
+      split1.end = interval.start;
+      split2.start = interval.end;
 
-        if (! split2.is_empty ())
-        {
-          database.addInterval (split2, verbose);
-        }
+      if (split1.is_empty ())
+      {
+        database.deleteInterval (overlap);
+      }
+      else
+      {
+        database.modifyInterval (overlap, split1, verbose);
+      }
+
+      if (! split2.is_empty ())
+      {
+        database.addInterval (split2, verbose);
       }
     }
   }
   return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-bool validate (
-  const CLI& cli,
-  const Rules& rules,
-  Database& database,
-  Interval& interval)
-{
-  // All validation performed here.
-  if (cli.getHint ("fill", false))
-  {
-    autoFill (rules, database, interval);
-  }
-
-  return autoAdjust (cli.getHint ("adjust", false), rules, database, interval);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/modify.t
+++ b/test/modify.t
@@ -312,6 +312,216 @@ class TestModify(TestCase):
 
         self.t("modify @1 range {:%Y-%m-%dT%H:%M:%S}Z".format(three_hours_before_utc))
 
+    def test_modify_range_with_fill_hint(self):
+        """Call modify range with :fill hint to expand interval to fill gaps"""
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
+        
+        # Create three intervals with gaps between them:
+        # @3: 4 hours ago for 30min (4:00 - 3:30)
+        # @2: 3:00 - 2:30 (gap: 3:30 - 3:00) 
+        # @1: 1:30 - 1:00 (gap: 2:30 - 1:30)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
+        one_hour_thirty_before_utc = now_utc - timedelta(hours=1, minutes=30)
+        two_hour_thirty_before_utc = now_utc - timedelta(hours=2, minutes=30)
+        three_hours_before_utc = now_utc - timedelta(hours=3)
+        three_hour_thirty_before_utc = now_utc - timedelta(hours=3, minutes=30)
+        four_hours_before_utc = now_utc - timedelta(hours=4)
+
+        # Create intervals @3, @2, @1 (in reverse chronological order)
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_three".format(four_hours_before_utc, three_hour_thirty_before_utc))
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_two".format(three_hours_before_utc, two_hour_thirty_before_utc))
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_one".format(one_hour_thirty_before_utc, one_hour_before_utc))
+
+        # Modify @2 with :fill hint - should expand to fill gaps between @3 and @1
+        code, out, err = self.t("modify @2 range :fill")
+
+        # Should see backfill and fill messages
+        self.assertIn('Backfilled', out)
+        self.assertIn('Filled', out)
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 3)
+        
+        # @3 should be unchanged
+        self.assertClosedInterval(j[0],
+                                expectedStart=four_hours_before_utc,
+                                expectedEnd=three_hour_thirty_before_utc,
+                                expectedTags=['task_three'])
+        
+        # @2 should now span from end of @3 to start of @1
+        self.assertClosedInterval(j[1],
+                                expectedStart=three_hour_thirty_before_utc,  # end of @3
+                                expectedEnd=one_hour_thirty_before_utc,     # start of @1
+                                expectedTags=['task_two'])
+        
+        # @1 should be unchanged
+        self.assertClosedInterval(j[2],
+                                expectedStart=one_hour_thirty_before_utc,
+                                expectedEnd=one_hour_before_utc,
+                                expectedTags=['task_one'])
+
+    def test_modify_range_with_fill_hint_no_adjacent_intervals(self):
+        """Call modify range with :fill hint when there are no adjacent intervals"""
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
+        
+        # Create a single isolated interval
+        two_hours_before_utc = now_utc - timedelta(hours=2)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
+
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_isolated".format(two_hours_before_utc, one_hour_before_utc))
+
+        # Modify @1 with :fill hint - should not change anything since there are no adjacent intervals
+        code, out, err = self.t("modify @1 range :fill")
+
+        # Should not see backfill or fill messages
+        self.assertNotIn('Backfilled', out)
+        self.assertNotIn('Filled', out)
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 1)
+        
+        # @1 should be unchanged since there are no adjacent intervals to fill to
+        self.assertClosedInterval(j[0],
+                                expectedStart=two_hours_before_utc,
+                                expectedEnd=one_hour_before_utc,
+                                expectedTags=['task_isolated'])
+
+    def test_modify_start_with_fill_hint(self):
+        """Call modify start with :fill hint to backfill start to adjacent interval"""
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
+        
+        # Create two intervals with a gap between them:
+        # @2: 3 hours ago for 30min (3:00 - 2:30)
+        # @1: 2 hours ago for 30min (2:00 - 1:30) - gap from 2:30 to 2:00
+        one_hour_thirty_before_utc = now_utc - timedelta(hours=1, minutes=30)
+        two_hours_before_utc = now_utc - timedelta(hours=2)
+        two_hour_thirty_before_utc = now_utc - timedelta(hours=2, minutes=30)
+        three_hours_before_utc = now_utc - timedelta(hours=3)
+
+        # Create intervals @2, @1 (in reverse chronological order)
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_two".format(three_hours_before_utc, two_hour_thirty_before_utc))
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_one".format(two_hours_before_utc, one_hour_thirty_before_utc))
+
+        # Modify @1 start with :fill hint - should backfill start to end of @2
+        code, out, err = self.t("modify @1 start :fill")
+
+        # Should see backfill message
+        self.assertIn('Backfilled', out)
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 2)
+        
+        # @2 should be unchanged
+        self.assertClosedInterval(j[0],
+                                expectedStart=three_hours_before_utc,
+                                expectedEnd=two_hour_thirty_before_utc,
+                                expectedTags=['task_two'])
+        
+        # @1 should have its start backfilled to end of @2
+        self.assertClosedInterval(j[1],
+                                expectedStart=two_hour_thirty_before_utc,  # end of @2
+                                expectedEnd=one_hour_thirty_before_utc,   # original end
+                                expectedTags=['task_one'])
+
+    def test_modify_end_with_fill_hint(self):
+        """Call modify end with :fill hint to fill end to adjacent interval"""
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
+        
+        # Create two intervals with a gap between them:
+        # @2: 3 hours ago for 30min (3:00 - 2:30) - gap from 2:30 to 2:00
+        # @1: 2 hours ago for 30min (2:00 - 1:30)
+        one_hour_thirty_before_utc = now_utc - timedelta(hours=1, minutes=30)
+        two_hours_before_utc = now_utc - timedelta(hours=2)
+        two_hour_thirty_before_utc = now_utc - timedelta(hours=2, minutes=30)
+        three_hours_before_utc = now_utc - timedelta(hours=3)
+
+        # Create intervals @2, @1 (in reverse chronological order)
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_two".format(three_hours_before_utc, two_hour_thirty_before_utc))
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_one".format(two_hours_before_utc, one_hour_thirty_before_utc))
+
+        # Modify @2 end with :fill hint - should fill end to start of @1
+        code, out, err = self.t("modify @2 end :fill")
+
+        # Should see fill message
+        self.assertIn('Filled', out)
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 2)
+        
+        # @2 should have its end filled to start of @1
+        self.assertClosedInterval(j[0],
+                                expectedStart=three_hours_before_utc,    # original start
+                                expectedEnd=two_hours_before_utc,        # start of @1
+                                expectedTags=['task_two'])
+        
+        # @1 should be unchanged
+        self.assertClosedInterval(j[1],
+                                expectedStart=two_hours_before_utc,
+                                expectedEnd=one_hour_thirty_before_utc,
+                                expectedTags=['task_one'])
+
+    def test_modify_start_with_fill_hint_no_previous_interval(self):
+        """Call modify start with :fill hint when there is no previous interval"""
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
+        
+        # Create a single isolated interval
+        two_hours_before_utc = now_utc - timedelta(hours=2)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
+
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_isolated".format(two_hours_before_utc, one_hour_before_utc))
+
+        # Modify @1 start with :fill hint - should not change anything since there is no previous interval
+        code, out, err = self.t("modify @1 start :fill")
+
+        # Should not see backfill message
+        self.assertNotIn('Backfilled', out)
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 1)
+        
+        # @1 should be unchanged since there is no previous interval
+        self.assertClosedInterval(j[0],
+                                expectedStart=two_hours_before_utc,
+                                expectedEnd=one_hour_before_utc,
+                                expectedTags=['task_isolated'])
+
+    def test_modify_end_with_fill_hint_no_next_interval(self):
+        """Call modify end with :fill hint when there is no next interval"""
+        now = datetime.now().replace(second=0, microsecond=0, minute=0)
+        now_utc = now.replace(tzinfo=tz.tzlocal()).astimezone(timezone.utc).replace(second=0, microsecond=0, minute=0)
+        
+        # Create a single isolated interval
+        two_hours_before_utc = now_utc - timedelta(hours=2)
+        one_hour_before_utc = now_utc - timedelta(hours=1)
+
+        self.t("track {:%Y-%m-%dT%H:%M:%S}Z - {:%Y-%m-%dT%H:%M:%S}Z task_isolated".format(two_hours_before_utc, one_hour_before_utc))
+
+        # Modify @1 end with :fill hint - should not change anything since there is no next interval
+        code, out, err = self.t("modify @1 end :fill")
+
+        # Should not see fill message
+        self.assertNotIn('Filled', out)
+
+        j = self.t.export()
+
+        self.assertEqual(len(j), 1)
+        
+        # @1 should be unchanged since there is no next interval
+        self.assertClosedInterval(j[0],
+                                expectedStart=two_hours_before_utc,
+                                expectedEnd=one_hour_before_utc,
+                                expectedTags=['task_isolated'])
+
 if __name__ == "__main__":
     from simpletap import TAPTestRunner
 


### PR DESCRIPTION
This PR enables the `:fill` hint for the modify command. The hint can be used as a replacement for the datetime or range, e.g.
```
timew modify @2 start :fill  # (1)
timew modify @2 end :fill    # (2)
timew modify @2 range :fill  # (3)
```

will modify the interval with id `@2` such that 
* the start is set to the end of the previous interval `(1)` (fill backward), 
* the end is set to the start of the following interval `(2)` (fill forward),
* the interval is extended to fill any gaps to its surrounding intervals `(3)`


Relates to #300 