### PR TITLE
check for timegm() function to avoid slow fallback implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set (HAVE_CMAKE true)
 project (timew)
 include (CXXSniffer)
 include (FindAsciidoctor)
+include (CheckFunctionExists)
 
 set (PROJECT_VERSION "1.9.0-dev")
 
@@ -44,6 +45,9 @@ else (FREEBSD OR DRAGONFLY)
 endif (FREEBSD OR DRAGONFLY)
 set (TIMEW_DOCDIR share/doc/timew CACHE STRING "Installation directory for doc files")
 set (TIMEW_BINDIR bin             CACHE STRING "Installation directory for Timewarrior executable")
+
+check_function_exists(strlcpy HAVE_STRLCPY)
+check_function_exists(timegm  HAVE_TIMEGM)
 
 message ("-- Configuring cmake.h")
 configure_file (${CMAKE_SOURCE_DIR}/cmake.h.in


### PR DESCRIPTION
Libshared pulled in a fallback `timegm()` implementation in GothenburgBitFactory/libshared#99 that's quite slow and caused an unintentional performance regression in timewarrior, as documented in #703.

The fix is to have `cmake` test for system `timegm()` and set the proper define so the code won't build the fallback version, but rather use the system one.

This patch brings in the libshared change from GothenburgBitFactory/libshared#105 that reads the cmake header, and then also adds the check+define in CMakeLists.txt so that the generated cmake.h that Datetime will now see (from libshared change) includes the right #define to avoid the slow fallback.

Fixes #703
