### PR TITLE
Move libshared into CMake subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ There are two ways to retrieve the Timewarrior sources:
   ```
 Build Timewarrior, optionally run the test suite, and install it.
 ```
-cmake -DCMAKE_BUILD_TYPE=release .
-make
-[make test]
-sudo make install
+cmake -DCMAKE_BUILD_TYPE=release -S . -B _build
+cmake --build _build -j
+[cmake --build _build --target timew_test]
+sudo cmake --install _build
 ```
 This copies files into the right place (default under `/usr/local`), and installs man pages.
 
 Add the optional parameter `-DCMAKE_INSTALL_PREFIX=/path/to/your/install/location` to the `cmake` command if you want to install Timewarrior at a location other than `/usr/local`.
-The `make install` command may not require `sudo` depending on your choice of install location.
+The `cmake --install` command may not require `sudo` depending on your choice of install location.
 
 ## Community
 [![Twitter](https://img.shields.io/twitter/follow/timewarrior_net?style=social)](https://twitter.com/timewarrior_net)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,36 +44,9 @@ set (timew_SRCS AtomicFile.cpp AtomicFile.h
                 util.cpp
                 validate.cpp)
 
-set (libshared_SRCS libshared/src/Args.cpp          libshared/src/Args.h
-                    libshared/src/Color.cpp         libshared/src/Color.h
-                    libshared/src/Composite.cpp     libshared/src/Composite.h
-                    libshared/src/Configuration.cpp libshared/src/Configuration.h
-                    libshared/src/Datetime.cpp      libshared/src/Datetime.h
-                    libshared/src/Duration.cpp      libshared/src/Duration.h
-                    libshared/src/FS.cpp            libshared/src/FS.h
-                    libshared/src/JSON.cpp          libshared/src/JSON.h
-                    libshared/src/Lexer.cpp         libshared/src/Lexer.h
-                    libshared/src/Msg.cpp           libshared/src/Msg.h
-                    libshared/src/Palette.cpp       libshared/src/Palette.h
-                    libshared/src/Pig.cpp           libshared/src/Pig.h
-                    libshared/src/RX.cpp            libshared/src/RX.h
-                    libshared/src/Table.cpp         libshared/src/Table.h
-                    libshared/src/Timer.cpp         libshared/src/Timer.h
-                    libshared/src/format.cpp        libshared/src/format.h
-                    libshared/src/shared.cpp        libshared/src/shared.h
-                    libshared/src/unicode.cpp       libshared/src/unicode.h
-                    libshared/src/utf8.cpp          libshared/src/utf8.h
-                                                    libshared/src/wcwidth.h)
-
-add_library (timew     STATIC ${timew_SRCS})
-add_library (libshared STATIC ${libshared_SRCS})
+add_subdirectory(${CMAKE_SOURCE_DIR}/src/libshared)
+add_library (timew  STATIC ${timew_SRCS})
 add_executable (timew_executable timew.cpp)
-add_executable (lex_executable   lex.cpp)
-
-target_link_libraries (timew_executable timew commands timew libshared ${TIMEW_LIBRARIES})
-target_link_libraries (lex_executable   timew                libshared ${TIMEW_LIBRARIES})
-
+target_link_libraries (timew_executable timew commands timew shared ${TIMEW_LIBRARIES})
 set_property (TARGET timew_executable PROPERTY OUTPUT_NAME "timew")
-set_property (TARGET lex_executable   PROPERTY OUTPUT_NAME "lex")
-
 install (TARGETS timew_executable DESTINATION ${TIMEW_BINDIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,13 +17,13 @@ if (uppercase_CMAKE_BUILD_TYPE MATCHES "DEBUG")
   if (FIU_ENABLE)
     message (STATUS "libfiu found")
     add_definitions (-DFIU_ENABLE)
-    set (test_LIBS fiu ${TIMEW_LIBRARIES})
+    set (timew_test_LIBS fiu ${TIMEW_LIBRARIES})
   else (FIU_ENABLE)
     message (STATUS "NOTE: install libfiu to run additional tests")
-    set (test_LIBS ${TIMEW_LIBRARIES})
+    set (timew_test_LIBS ${TIMEW_LIBRARIES})
   endif (FIU_ENABLE)
 else (uppercase_CMAKE_BUILD_TYPE MATCHES "DEBUG")
-  set (test_LIBS ${TIMEW_LIBRARIES})
+  set (timew_test_LIBS ${TIMEW_LIBRARIES})
 endif (uppercase_CMAKE_BUILD_TYPE MATCHES "DEBUG")
 
 include_directories (${CMAKE_SOURCE_DIR}
@@ -34,16 +34,16 @@ include_directories (${CMAKE_SOURCE_DIR}
 include_directories (${CMAKE_INSTALL_PREFIX}/include)
 link_directories(${CMAKE_INSTALL_PREFIX}/lib)
 
-set (test_SRCS AtomicFileTest data.t Datafile.t DatetimeParser.t exclusion.t helper.t interval.t range.t rules.t util.t TagInfoDatabase.t)
+set (timew_test_SRCS AtomicFileTest data.t Datafile.t DatetimeParser.t exclusion.t helper.t interval.t range.t rules.t util.t TagInfoDatabase.t)
 
-add_custom_target (test ./run_all --verbose
-                        DEPENDS ${test_SRCS} timew_executable doc
+add_custom_target (timew_test ./run_all --verbose
+                        DEPENDS ${timew_test_SRCS} timew_executable doc
                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test
                         COMMENT "Running testsuite...")
 
-foreach (src_FILE ${test_SRCS})
+foreach (src_FILE ${timew_test_SRCS})
   add_executable (${src_FILE} "${src_FILE}.cpp" test.cpp)
-  target_link_libraries (${src_FILE} timew libshared ${test_LIBS})
+  target_link_libraries (${src_FILE} timew shared ${timew_test_LIBS})
 endforeach (src_FILE)
 
 configure_file(run_all run_all COPYONLY)


### PR DESCRIPTION
Using libshared in a CMake subdirectory makes its targets automatically available in the parent project so we do not have to maintain duplicate CMake instructions to build libshared.