### PR TITLE
Fix code scanning alerts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 on: [push, pull_request, workflow_dispatch]
 jobs:
   tests:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,6 @@
 name: Update docs on ti.net
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for 
* [https://github.com/GothenburgBitFactory/timewarrior/security/code-scanning/2](https://github.com/GothenburgBitFactory/timewarrior/security/code-scanning/2)

To fix this problem, we should add an explicit `permissions:` block to the workflow file to ensure that the GitHub Actions job runs with only the minimum necessary permissions. Since the job does not appear to require any special privileges, the safest minimum is `contents: read` which allows reading repository code but not modifying it. This block should be placed at the very top level in the YAML file (right after the `name:` and before any jobs or steps), so it applies to all jobs in this workflow. No changes to other workflow logic are required.

* [https://github.com/GothenburgBitFactory/timewarrior/security/code-scanning/3](https://github.com/GothenburgBitFactory/timewarrior/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow at the root level (before `jobs:`) or within the job itself, specifying only the minimal necessary permissions. Since the workflow only needs to read the repository contents for checking out the code, the best setting is `contents: read`. This will ensure the GITHUB_TOKEN does not have write access, adhering to least privilege. In `.github/workflows/update-docs.yml`, add:

```yaml
permissions:
  contents: read
```

immediately after the `name: Update docs on ti.net` line, before `on:`.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

