### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,6 @@
 name: Update docs on ti.net
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/GothenburgBitFactory/timewarrior/security/code-scanning/3](https://github.com/GothenburgBitFactory/timewarrior/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow at the root level (before `jobs:`) or within the job itself, specifying only the minimal necessary permissions. Since the workflow only needs to read the repository contents for checking out the code, the best setting is `contents: read`. This will ensure the GITHUB_TOKEN does not have write access, adhering to least privilege. In `.github/workflows/update-docs.yml`, add:

```yaml
permissions:
  contents: read
```

immediately after the `name: Update docs on ti.net` line, before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
