### PR TITLE
Small fixes

### DIFF
--- a/doc/holidays/refresh
+++ b/doc/holidays/refresh
@@ -99,7 +99,7 @@ def update_locale_files(locales, regions, years):
 
                 except HTTPError as e:
                     if e.code == 404:
-                        print(f"holidata.net does not have data for {locale}, for {year}.")
+                        print(f"holidata.net does not provide data for locale {locale}, year {year}.")
                     else:
                         print(e.code, e.read())
 

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -154,7 +154,7 @@ void CLI::add (const std::string& argument)
   std::string clean;
   std::string::size_type i = 0;
   int character;
-  while ((character = utf8_next_char (argument.c_str (), i)))
+  while ((character = utf8_next_char (argument, i)))
   {
     if (character <= 32)
        clean += ' ';

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -150,7 +150,7 @@ void CLI::entity (const std::string& category, const std::string& name)
 // Capture a single argument.
 void CLI::add (const std::string& argument)
 {
-  // Sanitize the input: Convert control charts to spaces. Then trim.
+  // Sanitize the input: Convert control chars to spaces. Then trim.
   std::string clean;
   std::string::size_type i = 0;
   int character;

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -310,8 +310,7 @@ void Database::addInterval (const Interval& interval, bool verbose)
     }
   }
 
-  // Get the index into _files for the appropriate Datafile, which may be
-  // created on demand.
+  // Get the index into _files for the appropriate Datafile, which may be created on demand.
   auto df = getDatafile (interval.start.year (), interval.start.month ());
   _files[df].addInterval (interval);
   _journal->recordIntervalAction ("", interval.json ());

--- a/src/Rules.cpp
+++ b/src/Rules.cpp
@@ -107,7 +107,9 @@ Rules::Rules ()
 void Rules::load (const std::string& file, int nest /* = 1 */)
 {
   if (nest > 10)
+  {
     throw std::string ("Rules files may only be nested to 10 levels.");
+  }
 
   if (nest == 1)
   {
@@ -115,10 +117,14 @@ void Rules::load (const std::string& file, int nest /* = 1 */)
     _original_file = originalFile._data;
 
     if (! originalFile.exists ())
+    {
       throw std::string ("ERROR: Configuration file not found.");
+    }
 
     if (! originalFile.readable ())
+    {
       throw std::string ("ERROR: Configuration file cannot be read (insufficient privileges).");
+    }
   }
 
   // Read the file, then parse the contents.
@@ -126,7 +132,8 @@ void Rules::load (const std::string& file, int nest /* = 1 */)
   try
   {
     AtomicFile::read (file, contents);
-    if (contents.length ())
+
+    if (!contents.empty ())
     {
       parse (contents, nest);
     }
@@ -166,16 +173,18 @@ std::string Rules::get (const std::string& key, const std::string& defaultValue)
 int Rules::getInteger (const std::string& key, int defaultValue) const
 {
   auto found = _settings.find (key);
+
   if (found != _settings.end ())
   {
     int value = strtoimax (found->second.c_str (), nullptr, 10);
 
-    // Invalid values are handled.  ERANGE errors are simply capped by
-    // strtoimax, which is desired behavior.
-    // Note that not all platforms behave alike, and the EINVAL is not
-    // necessarily returned.
+    // Invalid values are handled.
+    // ERANGE errors are simply capped by strtoimax, which is desired behavior.
+    // Note that not all platforms behave alike, and the EINVAL is not necessarily returned.
     if (value == 0 && (errno == EINVAL || found->second != "0"))
+    {
       throw format ("Invalid integer value for '{1}': '{2}'", key, found->second);
+    }
 
     return value;
   }
@@ -187,8 +196,11 @@ int Rules::getInteger (const std::string& key, int defaultValue) const
 double Rules::getReal (const std::string& key) const
 {
   auto found = _settings.find (key);
+
   if (found != _settings.end ())
+  {
     return strtod (found->second.c_str (), nullptr);
+  }
 
   return 0.0;
 }
@@ -201,6 +213,7 @@ bool Rules::getBoolean (const std::string& key, bool defaultValue) const
   if (found != _settings.end ())
   {
     auto value = lowerCase (found->second);
+
     if (value == "true"   ||
         value == "1"      ||
         value == "y"      ||
@@ -240,9 +253,14 @@ void Rules::set (const std::string& key, const std::string& value)
 std::vector <std::string> Rules::all (const std::string& stem) const
 {
   std::vector <std::string> items;
+
   for (const auto& it : _settings)
+  {
     if (stem.empty () || it.first.find (stem) == 0)
+    {
       items.push_back (it.first);
+    }
+  }
 
   return items;
 }
@@ -251,7 +269,9 @@ std::vector <std::string> Rules::all (const std::string& stem) const
 bool Rules::isRuleType (const std::string& type) const
 {
   if (std::find (_rule_types.begin (), _rule_types.end (), type) != _rule_types.end ())
+  {
     return true;
+  }
 
   return false;
 }
@@ -260,13 +280,17 @@ bool Rules::isRuleType (const std::string& type) const
 std::string Rules::dump () const
 {
   std::stringstream out;
+
   out << "Rules\n"
       << "  _original_file " << _original_file
       << '\n';
 
   out << "  Settings\n";
+
   for (const auto& item : _settings)
+  {
     out << "    " << item.first << "=" << item.second << '\n';
+  }
 
   return out.str ();
 }
@@ -281,6 +305,7 @@ void Rules::parse (const std::string& input, int nest /* = 1 */)
   for (auto& line : split (input, '\n'))
   {
     auto comment = line.find ("#");
+
     if (comment != std::string::npos)
     {
       line.resize (comment);
@@ -292,6 +317,7 @@ void Rules::parse (const std::string& input, int nest /* = 1 */)
     auto indent = line.find_first_not_of (' ');
 
     auto tokens = Lexer::tokenize (line);
+
     if (! tokens.empty ())
     {
       if (inRule)
@@ -329,7 +355,6 @@ void Rules::parse (const std::string& input, int nest /* = 1 */)
           inRule = true;
           ruleDef = line + '\n';
         }
-
         // Top-level import:
         //   'import' <file>
         else if (firstWord == "import" &&
@@ -345,21 +370,18 @@ void Rules::parse (const std::string& input, int nest /* = 1 */)
 
           load (imported._data, nest + 1);
         }
-
         // Top-level settings:
         //   <name> '=' <value>
         else if (tokens.size () >= 3 &&
                  std::get <0> (tokens[1]) == "=")
         {
-          // If this line is an assignment, then tokenizing it is a mistake, so
-          // use the raw data from 'line'.
+          // If this line is an assignment, then tokenizing it is a mistake, so use the raw data from 'line'.
           auto equals = line.find ('=');
           assert (equals != std::string::npos);
 
           set (trim (line.substr (indent, equals - indent)),
                trim (line.substr (equals + 1)));
         }
-
         // Top-level settings, with no value:
         //   <name> '='
         else if (tokens.size () == 2 &&
@@ -367,16 +389,19 @@ void Rules::parse (const std::string& input, int nest /* = 1 */)
         {
           set (firstWord, "");
         }
-
         // Admit defeat.
         else
+        {
           throw format ("Unrecognized construct: {1}", line);
+        }
       }
     }
   }
 
   if (! ruleDef.empty ())
+  {
     parseRule (ruleDef);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -390,21 +415,26 @@ void Rules::parseRule (const std::string& input)
   std::string token;
   Lexer::Type type;
   Lexer lexer (lines[0]);
-  while (lexer.token (token, type))
-    tokens.push_back (token);
 
-  // Based on the tokens of the first line, determine which rule type needs to
-  // be parsed.
+  while (lexer.token (token, type))
+  {
+    tokens.push_back (token);
+  }
+
+  // Based on the tokens of the first line, determine which rule type needs to be parsed.
   if (tokens.size () >= 2 &&
       tokens[0] == "define")
   {
     if (tokens.size () >= 2 &&
         isRuleType (tokens[1].substr (0, tokens[1].length () - 1)))
+    {
       parseRuleSettings (lines);
-
+    }
     // Error.
     else
+    {
       throw format ("Unrecognized rule type '{1}'", join (" ", tokens));
+    }
   }
 }
 
@@ -424,8 +454,9 @@ void Rules::parseRuleSettings (
 
     // Capture increased indentation.
     if (indent > indents.back ())
+    {
       indents.push_back (indent);
-
+    }
     // If indent decreased.
     else if (indent < indents.back ())
     {
@@ -437,21 +468,27 @@ void Rules::parseRuleSettings (
 
       // Spot raggedy-ass indentation.
       if (indent != indents.back ())
+      {
         throw std::string ("Syntax error in rule: mismatched indent.");
+      }
     }
 
     // Descend.
     if (! group.empty ())
+    {
       hierarchy.push_back (group);
+    }
 
     // Settings.
     if (tokens.size () >= 3 && tokens[1] == "=")
     {
       auto name  = join (".", hierarchy) + "." + tokens[0];
-
       auto equals = line.find ('=');
+
       if (equals == std::string::npos)
+      {
         throw format ("Syntax error in rule: missing '=' in line '{1}'.", line);
+      }
 
       auto value = Lexer::dequote (trim (line.substr (equals + 1)));
       set (name, value);
@@ -461,15 +498,20 @@ void Rules::parseRuleSettings (
   // Should arrive here with indents and hierarchy in their original state.
   if (indents.size () != 1 ||
       indents[0] != 0)
+  {
     throw std::string ("Syntax error - indentation is not right.");
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 unsigned int Rules::getIndentation (const std::string& line)
 {
   auto indent = line.find_first_not_of (' ');
+
   if (indent == std::string::npos)
+  {
     indent = 0;
+  }
 
   return indent;
 }
@@ -482,8 +524,11 @@ std::vector <std::string> Rules::tokenizeLine (const std::string& line)
   std::string token;
   Lexer::Type type;
   Lexer lexer (line);
+
   while (lexer.token (token, type))
+  {
     tokens.push_back (token);
+  }
 
   return tokens;
 }
@@ -495,15 +540,19 @@ std::vector <std::string> Rules::tokenizeLine (const std::string& line)
 std::string Rules::parseGroup (const std::vector <std::string>& tokens)
 {
   auto count = tokens.size ();
+
   if (count)
   {
     auto last = tokens.back ();
 
     if (count >= 2 && last == ":")
+    {
       return tokens[count - 2];
-
+    }
     else if (count >= 1 && last[last.length () - 1] == ':')
+    {
       return last.substr (0, last.length () - 1);
+    }
   }
 
   return "";
@@ -516,8 +565,8 @@ std::string Rules::parseGroup (const std::vector <std::string>& tokens)
 bool Rules::setConfigVariable (
   Journal& journal,
   const Rules& rules,
-  std::string name,
-  std::string value,
+  const std::string& name,
+  const std::string& value,
   bool confirmation /* = false */)
 {
   // Read config file as lines of text.
@@ -530,7 +579,9 @@ bool Rules::setConfigVariable (
   {
     // No change.
     if (rules.get (name) == value)
+    {
       return false;
+    }
 
     // If there is a non-comment line containing the entry in flattened form:
     //   a.b.c = value
@@ -539,6 +590,7 @@ bool Rules::setConfigVariable (
     {
       auto comment = line.find ('#');
       auto pos     = line.find (name);
+
       if (pos != std::string::npos &&
           (comment == std::string::npos || comment > pos))
       {
@@ -552,7 +604,7 @@ bool Rules::setConfigVariable (
                              value)))
         {
           auto before = line;
-          line = line.substr (0, pos) + name + " = " + value;
+          line = line.substr (0, pos).append (name).append (" = ").append (value);
 
           journal.recordConfigAction (before, line);
 
@@ -572,6 +624,7 @@ bool Rules::setConfigVariable (
       {
         auto comment = line.find ('#');
         auto pos     = line.find (leaf);
+
         if (pos != std::string::npos &&
             (comment == std::string::npos || comment > pos))
         {
@@ -585,7 +638,7 @@ bool Rules::setConfigVariable (
                                value)))
           {
             auto before = line;
-            line = line.substr (0, pos) + leaf + " " + value;
+            line = line.substr (0, pos).append (leaf).append (" ").append (value);
 
             journal.recordConfigAction (before, line);
 
@@ -594,6 +647,7 @@ bool Rules::setConfigVariable (
         }
       }
     }
+
     if (! found)
     {
       // Remove name
@@ -605,7 +659,9 @@ bool Rules::setConfigVariable (
       {
         // Add blank line required by rules.
         if (lines.empty () || lines.back ().empty ())
+        {
           lines.emplace_back ("");
+        }
 
         // Add new line.
         lines.push_back (name + " = " + json::encode (value));
@@ -621,12 +677,14 @@ bool Rules::setConfigVariable (
     if (! confirmation ||
         confirm (format ("Are you sure you want to add '{1}' with a value of '{2}'?", name, value)))
     {
-      // TODO Ideally, this would locate an existing hierarchy and insert the
-      //      new leaf/value properly. But that's non-trivial.
+      // TODO Ideally, this would locate an existing hierarchy and insert the new leaf/value properly.
+      //      But that's non-trivial.
 
       // Add blank line required by rules.
       if (lines.empty () || lines.back ().empty ())
+      {
         lines.emplace_back ("");
+      }
 
       // Add new line.
       lines.push_back (name + " = " + json::encode (value));
@@ -655,12 +713,14 @@ bool Rules::setConfigVariable (
 int Rules::unsetConfigVariable (
   Journal& journal,
   const Rules& rules,
-  std::string name,
+  const std::string& name,
   bool confirmation /* = false */)
 {
   // Setting not found.
   if (! rules.has (name))
+  {
     return 2;
+  }
 
   // Read config file as lines of text.
   std::vector <std::string> lines;
@@ -670,10 +730,12 @@ int Rules::unsetConfigVariable (
   //   a.b.c = value
   bool found = false;
   bool change = false;
+
   for (auto& line : lines)
   {
     auto comment = line.find ('#');
     auto pos     = line.find (name);
+
     if (pos != std::string::npos &&
         (comment == std::string::npos || comment > pos))
     {
@@ -698,10 +760,12 @@ int Rules::unsetConfigVariable (
   if (! found)
   {
     auto leaf = split (name, '.').back () + ":";
+
     for (auto& line : lines)
     {
       auto comment = line.find ('#');
       auto pos     = line.find (leaf);
+
       if (pos != std::string::npos &&
           (comment == std::string::npos || comment > pos))
       {
@@ -724,9 +788,13 @@ int Rules::unsetConfigVariable (
   }
 
   if (change && found)
+  {
     return 0;
+  }
   else if (found)
+  {
     return 1;
+  }
 
   return 2;
 }

--- a/src/Rules.h
+++ b/src/Rules.h
@@ -56,8 +56,8 @@ public:
 
   std::string dump () const;
 
-  static bool setConfigVariable (Journal&, const Rules&, std::string, std::string, bool confirmation);
-  static int unsetConfigVariable (Journal&, const Rules&, std::string, bool confirmation);
+  static bool setConfigVariable (Journal&, const Rules&, const std::string&, const std::string&, bool confirmation);
+  static int unsetConfigVariable (Journal&, const Rules&, const std::string&, bool confirmation);
 
 private:
   void parse               (const std::string&, int = 1);
@@ -72,7 +72,6 @@ private:
   std::string                         _original_file {};
   std::map <std::string, std::string> _settings      {};
   std::vector <std::string>           _rule_types    {"tags", "reports", "theme", "holidays", "exclusions"};
-
 };
 
 #endif

--- a/src/commands/CmdConfig.cpp
+++ b/src/commands/CmdConfig.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <JSON.h>
+#include <Rules.h>
 #include <commands.h>
 #include <format.h>
 #include <iostream>

--- a/src/commands/CmdMove.cpp
+++ b/src/commands/CmdMove.cpp
@@ -104,8 +104,7 @@ int CmdMove (
   // Move start time.
   Datetime start (new_start);
 
-  // Changing the start date should also change the end date by the same
-  // amount.
+  // Changing the start date should also change the end date by the same amount.
   if (interval.start < start)
   {
     auto delta = start - interval.start;

--- a/src/commands/CmdUndo.cpp
+++ b/src/commands/CmdUndo.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <IntervalFactory.h>
+#include <Rules.h>
 #include <commands.h>
 #include <format.h>
 #include <iostream>

--- a/test/AtomicFile.t
+++ b/test/AtomicFile.t
@@ -1,13 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 BASEDIR="$( dirname "$0" )"
 
 if [ "$(uname -s)" = "Darwin" ] ; then
-  DLL_TOOL="otool -L"
+  DLL_TOOL=("otool" "-L")
 else
-  DLL_TOOL="ldd"
+  DLL_TOOL=("ldd")
 fi
 
-if "${DLL_TOOL}" "${BASEDIR}/AtomicFileTest" | grep -q 'libfiu' ; then
+if "${DLL_TOOL[@]}" "${BASEDIR}/AtomicFileTest" | grep -q 'libfiu' ; then
     exec fiu-run -x "${BASEDIR}/AtomicFileTest"
 else
     exec "${BASEDIR}/AtomicFileTest"


### PR DESCRIPTION
Some small fixes that have gathered up:
* Add missing includes to commands `configure` and `undo`
* Small refactoring of Rules class
  - Use const reference
  - Use 'empty ()' instead of 'length ()'
  - Use append instead of string concatenation
  - Apply codestyle
    - Use curly braces
    - Add whitespace before flow control statements
    - Remove superfluous whitespace
    - Reformat comments
- Remove redundant call to 'c_str ()' in `CLI.cpp`
- Reformat/fix comments in `CmdMove.cpp`, `CLI.cpp`, `Database.cpp`
- Improve error message on missing holidata in `refresh` script
- Fix AtomicFile.t
  - Use Bash in shebang
  - Fix call to DLL_TOOL on Darwin
