### PR TITLE
read $COLUMNS before defaulting width 80 when no tty

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -528,6 +528,15 @@ int getTerminalWidth ()
   terminalWidth = ts.ws_col;
 #endif
 
+  if (terminalWidth == 0)
+  {
+    char *columns = getenv ("COLUMNS");
+    if (columns != NULL)
+    {
+      terminalWidth = atoi (columns);
+    }
+  }
+
   return terminalWidth > 0 ? terminalWidth : 80;
 }
 


### PR DESCRIPTION
This patch attempts to let the user override the "not/unknown terminal" width using a standard environment variable.  When stdin is not a tty, we'll default to `$COLUMNS`, rather than the hardcoded 80, if `atoi()` works on the value.  If not sane or not present, defaults to 80 columns as before.  This is likely to work correctly in most scenarios and not change existing behavior, because `$COLUMNS` would usually only be set for a terminal, and the termios determination will override the environment there.

Use case: a keybind for `timew summary :day` in window manager to display in a transient window.  Bound action executes in a fork of the wm, which doesn't have a tty, and its stdin/out/err are `/dev/null`.  After the recent #566, the summary output is now always 80 columns therein.  So this patch gives a workaround and should have good behavior for everyone.

Please apply, thanks.
