### PR TITLE
Support coloring of tags with special characters

### DIFF
--- a/src/Rules.cpp
+++ b/src/Rules.cpp
@@ -372,22 +372,12 @@ void Rules::parse (const std::string& input, int nest /* = 1 */)
         }
         // Top-level settings:
         //   <name> '=' <value>
-        else if (tokens.size () >= 3 &&
-                 std::get <0> (tokens[1]) == "=")
+        //   <name> '='
+        else if (auto equals = line.find ('='); equals != std::string::npos)
         {
           // If this line is an assignment, then tokenizing it is a mistake, so use the raw data from 'line'.
-          auto equals = line.find ('=');
-          assert (equals != std::string::npos);
-
           set (trim (line.substr (indent, equals - indent)),
                trim (line.substr (equals + 1)));
-        }
-        // Top-level settings, with no value:
-        //   <name> '='
-        else if (tokens.size () == 2 &&
-                 std::get <0> (tokens[1]) == "=")
-        {
-          set (firstWord, "");
         }
         // Admit defeat.
         else

--- a/test/config.t
+++ b/test/config.t
@@ -197,6 +197,14 @@ class TestConfig(TestCase):
         code, out, err = self.t("config")
         self.assertIn("month = ", out)
 
+    def test_set_tag_with_dashes_color(self):
+        """Test setting tag color with dashes in tag name"""
+        self.t.config("tags.tag-with-dashes.color", "black on yellow")
+
+        code, out, err = self.t("config")
+        self.assertIn("tag-with-dashes", out)
+        self.assertIn("color = black on yellow", out)
+
     def test_unset_known_hierarchical_name(self):
         """Test unsetting a known hierarchical name"""
         code, out, err = self.t.runError("config reports.day.month :yes")


### PR DESCRIPTION
As described in #591, adding coloring to a tag `tag-with-dashes` via config breaks the configuration parsing:

```
tags.tag-with-dashes.color = black on yellow
```

Additionally, anything that comes _after_ this line in the configuration file is no longer applied.

The reason for this lies in the way the configuration file is parsed, wrongly assuming that everything in front of the `=` is recognised as a single token by the lexer.

This pull request simplifies the parsing logic by checking if the current line contains a `=` symbol. If that's the case, the substrings before and after the symbol are treated as the assigned name and value. This also simplifies the case for settings with no value.