### PR TITLE
remove dateutil dependency from totals.py

### DIFF
--- a/ext/totals.py
+++ b/ext/totals.py
@@ -30,8 +30,6 @@ import datetime
 import json
 import sys
 
-from dateutil import tz
-
 DATEFORMAT = "%Y%m%dT%H%M%SZ"
 
 
@@ -48,8 +46,8 @@ def format_seconds(seconds):
 
 
 def calculate_totals(input_stream):
-    from_zone = tz.tzutc()
-    to_zone = tz.tzlocal()
+    from_zone = datetime.timezone.utc
+    to_zone = datetime.datetime.now().astimezone().tzinfo
 
     # Extract the configuration settings.
     header = 1


### PR DESCRIPTION
Use datetime from the standard library, instead of the third-party module 'dateutil'

This allows totals.py to run on a standard python3 installation. Confirmed working with Python 3.13.

Fixes #764